### PR TITLE
Spill diff rows to disk during accumulation to prevent OOM

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,7 +31,9 @@ The [`ace.yaml` file](https://github.com/pgEdge/ace/blob/main/ace.yaml) defines 
 | table_diff --> concurrency_factor | CPU ratio for diff concurrency (0.0–4.0, e.g. 0.5 uses half of available CPUs). **Default: 0.5** |
 | table_diff --> min_diff_block_size | Minimum diff block (row chunk) size. **Default: 1** |
 | table_diff --> max_diff_block_size | Maximum diff block size. **Default: 1000000** |
+| table_diff --> max_diff_rows | Stop diffing after this many mismatched rows are found. `0` = no limit. **Default: 1000000** |
 | table_diff --> compare_unit_size | Unit size for smallest comparison chunk. **Default: 10000** |
+| table_diff --> diff_spill_threshold | Number of diff rows to hold in memory per node-pair/node before spilling to a temporary file on disk. Prevents OOM on very large diffs. `0` uses the built-in default. **Default: 10000** |
 | mtree → cdc --> slot_name | Logical decoding slot name for mtree CDC. **Default: "ace_mtree_slot"** |
 | mtree → cdc --> publication_name | Publication used for mtree CDC. **Default: "ace_mtree_pub"** |
 | mtree → cdc --> cdc_processing_timeout | CDC processing timeout (s). **Default: 30** |

--- a/docs/design/table_diff.md
+++ b/docs/design/table_diff.md
@@ -165,6 +165,7 @@ flowchart LR
 - **concurrency_factor**: CPU ratio (0.0–4.0) that scales workers relative to `NumCPU` (e.g. 0.5 on a 16-CPU host spawns 8 workers). Higher = faster hashing but more load on DB backends, network, and local CPU; can contend with other workloads and connection limits.
 - **compare_unit_size**: Lower values push recursion deeper (more queries, smaller fetches); higher values stop earlier (fewer queries, larger fetches on mismatched ranges).
 - **max_diff_rows**: Early-exit guardrail. Lower caps keep runs short and reports small on divergent tables; raising/removing can grow memory and report size when drift is large.
+- **diff_spill_threshold**: Max diff rows held in memory per (node-pair, node) before spilling to a temp file. When a large number of rows differ (e.g. 250K+ with JSONB columns), keeping them all in memory can cause OOM. The spill mechanism writes overflow rows to a temporary NDJSON file during accumulation and reads them back at report time. Higher values reduce disk I/O overhead; lower values reduce peak memory. **Default: 10000**.
 - **table_filter**: Narrows scope and cost; enables accurate `COUNT(*)` on the filtered view. Must be identical across nodes to avoid false positives.
 - **override_block_size**: Skips safety rails from `ace.yaml`. Oversized blocks can spike memory and slow hashes, especially on wide rows.
 - **output (json/html)**: HTML adds minor post-processing; DB load is unaffected.

--- a/internal/cli/default_config.yaml
+++ b/internal/cli/default_config.yaml
@@ -22,6 +22,7 @@ postgres:
 table_diff:
   concurrency_factor: 0.5
   max_diff_rows: 1000000
+  diff_spill_threshold: 10000
   min_diff_block_size: 1
   max_diff_block_size: 1000000
   diff_block_size: 1000

--- a/internal/consistency/diff/table_diff.go
+++ b/internal/consistency/diff/table_diff.go
@@ -103,10 +103,12 @@ type TableDiffTask struct {
 
 	SpockNodeNames map[string]string
 
-	CompareUnitSize int
-	MaxDiffRows     int64
+	CompareUnitSize    int
+	MaxDiffRows        int64
+	DiffSpillThreshold int
 
 	DiffResult types.DiffOutput
+	diffSinks  utils.DiffSinks
 	diffMutex  sync.Mutex
 
 	firstError   error
@@ -742,6 +744,10 @@ func (t *TableDiffTask) Validate() error {
 		t.MaxDiffRows = cfg.TableDiff.MaxDiffRows
 	}
 
+	if t.DiffSpillThreshold == 0 && cfg.TableDiff.DiffSpillThreshold > 0 {
+		t.DiffSpillThreshold = cfg.TableDiff.DiffSpillThreshold
+	}
+
 	if t.ConcurrencyFactor > 4.0 || t.ConcurrencyFactor <= 0 {
 		return fmt.Errorf("invalid value range for concurrency_factor, must be > 0 and <= 4.0")
 	}
@@ -1039,6 +1045,7 @@ func (t *TableDiffTask) CloneForSchedule(ctx context.Context) *TableDiffTask {
 	cloned.InvokeMethod = t.InvokeMethod
 	cloned.CompareUnitSize = t.CompareUnitSize
 	cloned.MaxDiffRows = t.MaxDiffRows
+	cloned.DiffSpillThreshold = t.DiffSpillThreshold
 	cloned.EnsurePgcrypto = t.EnsurePgcrypto
 	cloned.AgainstOrigin = t.AgainstOrigin
 	cloned.Until = t.Until
@@ -1334,6 +1341,7 @@ func (t *TableDiffTask) ExecuteTask() (err error) {
 			OriginOnly: t.resolvedAgainstOrigin != "",
 		},
 	}
+	t.diffSinks = make(utils.DiffSinks)
 
 	sampleMethod := "BERNOULLI"
 	samplePercent := 0.0
@@ -1602,7 +1610,8 @@ func (t *TableDiffTask) ExecuteTask() (err error) {
 
 	t.AddPrimaryKeyToDiffSummary()
 
-	jsonPath, _, err := utils.WriteDiffReport(t.DiffResult, t.Schema, t.BaseTable, t.Output)
+	jsonPath, _, err := utils.WriteDiffReport(t.DiffResult, t.diffSinks, t.Schema, t.BaseTable, t.Output)
+	t.diffSinks.CloseAll()
 	if err != nil {
 		return err
 	}
@@ -1921,12 +1930,8 @@ func (t *TableDiffTask) recursiveDiff(
 				}
 			}
 
-			if _, ok := t.DiffResult.NodeDiffs[pairKey].Rows[node1Name]; !ok {
-				t.DiffResult.NodeDiffs[pairKey].Rows[node1Name] = []types.OrderedMap{}
-			}
-			if _, ok := t.DiffResult.NodeDiffs[pairKey].Rows[node2Name]; !ok {
-				t.DiffResult.NodeDiffs[pairKey].Rows[node2Name] = []types.OrderedMap{}
-			}
+			sink1 := t.diffSinks.GetSink(pairKey, node1Name, t.DiffSpillThreshold)
+			sink2 := t.diffSinks.GetSink(pairKey, node2Name, t.DiffSpillThreshold)
 
 			for _, row := range diffInfo.Node1OnlyRows {
 				if t.shouldStopDueToLimit() {
@@ -1936,7 +1941,11 @@ func (t *TableDiffTask) recursiveDiff(
 				rowAsMap := utils.OrderedMapToMap(row)
 				rowWithMeta := t.withSpockMetadata(rowAsMap)
 				rowAsOrderedMap := utils.MapToOrderedMap(rowWithMeta, t.Cols)
-				t.DiffResult.NodeDiffs[pairKey].Rows[node1Name] = append(t.DiffResult.NodeDiffs[pairKey].Rows[node1Name], rowAsOrderedMap)
+				if err := sink1.Append(rowAsOrderedMap); err != nil {
+					t.diffMutex.Unlock()
+					t.recordError(err)
+					return
+				}
 				currentDiffRowsForPair++
 				if t.incrementDiffRowsLocked(1) {
 					limitReached = true
@@ -1953,7 +1962,11 @@ func (t *TableDiffTask) recursiveDiff(
 					rowAsMap := utils.OrderedMapToMap(row)
 					rowWithMeta := t.withSpockMetadata(rowAsMap)
 					rowAsOrderedMap := utils.MapToOrderedMap(rowWithMeta, t.Cols)
-					t.DiffResult.NodeDiffs[pairKey].Rows[node2Name] = append(t.DiffResult.NodeDiffs[pairKey].Rows[node2Name], rowAsOrderedMap)
+					if err := sink2.Append(rowAsOrderedMap); err != nil {
+						t.diffMutex.Unlock()
+						t.recordError(err)
+						return
+					}
 					currentDiffRowsForPair++
 					if t.incrementDiffRowsLocked(1) {
 						limitReached = true
@@ -1971,12 +1984,20 @@ func (t *TableDiffTask) recursiveDiff(
 					node1DataAsMap := utils.OrderedMapToMap(modRow.Node1Data)
 					node1DataWithMeta := t.withSpockMetadata(node1DataAsMap)
 					node1DataAsOrderedMap := utils.MapToOrderedMap(node1DataWithMeta, t.Cols)
-					t.DiffResult.NodeDiffs[pairKey].Rows[node1Name] = append(t.DiffResult.NodeDiffs[pairKey].Rows[node1Name], node1DataAsOrderedMap)
+					if err := sink1.Append(node1DataAsOrderedMap); err != nil {
+						t.diffMutex.Unlock()
+						t.recordError(err)
+						return
+					}
 
 					node2DataAsMap := utils.OrderedMapToMap(modRow.Node2Data)
 					node2DataWithMeta := t.withSpockMetadata(node2DataAsMap)
 					node2DataAsOrderedMap := utils.MapToOrderedMap(node2DataWithMeta, t.Cols)
-					t.DiffResult.NodeDiffs[pairKey].Rows[node2Name] = append(t.DiffResult.NodeDiffs[pairKey].Rows[node2Name], node2DataAsOrderedMap)
+					if err := sink2.Append(node2DataAsOrderedMap); err != nil {
+						t.diffMutex.Unlock()
+						t.recordError(err)
+						return
+					}
 					currentDiffRowsForPair++
 					if t.incrementDiffRowsLocked(1) {
 						limitReached = true

--- a/internal/consistency/mtree/merkle.go
+++ b/internal/consistency/mtree/merkle.go
@@ -92,8 +92,10 @@ type MerkleTreeTask struct {
 
 	mtreeSchema string
 
-	DiffResult  types.DiffOutput
-	diffMutex   sync.Mutex
+	DiffResult         types.DiffOutput
+	diffSinks          utils.DiffSinks
+	DiffSpillThreshold int
+	diffMutex          sync.Mutex
 	diffRowKeySets map[string]map[string]map[string]struct{}
 	StartTime      time.Time
 	SpockNodeNames map[string]string
@@ -622,7 +624,9 @@ func (m *MerkleTreeTask) addRowToDiff(nodePairKey, nodeName string, row types.Or
 	}
 
 	nodeSet[key] = struct{}{}
-	m.DiffResult.NodeDiffs[nodePairKey].Rows[nodeName] = append(m.DiffResult.NodeDiffs[nodePairKey].Rows[nodeName], orderedRow)
+	if err := m.diffSinks.GetSink(nodePairKey, nodeName, m.DiffSpillThreshold).Append(orderedRow); err != nil {
+		return false, err
+	}
 	return true, nil
 }
 
@@ -1913,6 +1917,7 @@ func (m *MerkleTreeTask) DiffMtree() (err error) {
 		},
 	}
 	m.diffRowKeySets = make(map[string]map[string]map[string]struct{})
+	m.diffSinks = make(utils.DiffSinks)
 
 	for _, pair := range nodePairs {
 		node1 := pair[0]
@@ -2010,9 +2015,12 @@ func (m *MerkleTreeTask) DiffMtree() (err error) {
 		m.DiffResult.Summary.EndTime = endTime.Format(time.RFC3339)
 		m.DiffResult.Summary.TimeTaken = endTime.Sub(m.StartTime).String()
 		m.DiffResult.Summary.PrimaryKey = m.Key
-		if diffPath, _, writeErr := utils.WriteDiffReport(m.DiffResult, m.Schema, m.Table, m.Output); writeErr != nil {
+		diffPath, _, writeErr := utils.WriteDiffReport(m.DiffResult, m.diffSinks, m.Schema, m.Table, m.Output)
+		m.diffSinks.CloseAll()
+		if writeErr != nil {
 			return writeErr
-		} else if diffPath != "" {
+		}
+		if diffPath != "" {
 			resultCtx["diff_file"] = diffPath
 		}
 	}

--- a/pkg/common/diff_sink.go
+++ b/pkg/common/diff_sink.go
@@ -1,0 +1,225 @@
+// ///////////////////////////////////////////////////////////////////////////
+//
+// # ACE - Active Consistency Engine
+//
+// Copyright (C) 2023 - 2026, pgEdge (https://www.pgedge.com/)
+//
+// This software is released under the PostgreSQL License:
+// https://opensource.org/license/postgresql
+//
+// ///////////////////////////////////////////////////////////////////////////
+
+package common
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/pgedge/ace/pkg/types"
+)
+
+// DiffRowSink accumulates diff rows during table-diff / mtree-diff, spilling
+// to a temporary NDJSON file on disk when the in-memory row count exceeds a
+// configurable threshold (default 10 000 rows).
+//
+// Architecture overview:
+//
+//   - During diffing, concurrent goroutines discover mismatched rows and call
+//     Append() under the task's diffMutex. Rows are buffered in memory; when
+//     the buffer reaches the threshold the entire buffer is flushed to a temp
+//     NDJSON (newline-delimited JSON) file and the buffer is reset.
+//
+//   - One sink exists per (nodePair, nodeName) combination. For a typical
+//     2-node cluster that is 2 sinks. Memory is bounded to roughly
+//     threshold × row_size × number_of_sinks regardless of total diff count.
+//
+//   - At report time, WriteDiffReport calls SortedIterate on each sink
+//     sequentially. This loads one sink's rows back into memory, sorts by
+//     primary key, streams the sorted rows to the JSON output file, then
+//     releases them before moving to the next sink. Peak memory during the
+//     write phase is therefore one sink's worth of rows.
+//
+//   - Downstream consumers (repair, rerun) read from the written JSON file,
+//     not from the sinks, so they are unaffected by this change.
+//
+// DiffRowSink is NOT safe for concurrent use — callers must synchronize
+// externally (e.g. via diffMutex).
+type DiffRowSink struct {
+	rows      []types.OrderedMap
+	count     int // total rows (memory + spilled)
+	threshold int // flush to disk when len(rows) reaches this
+
+	spillFile *os.File
+	spilled   int // rows written to spillFile
+}
+
+const defaultSpillThreshold = 10_000
+
+// NewDiffRowSink creates a sink that keeps up to threshold rows in memory.
+// If threshold <= 0, defaultSpillThreshold is used.
+func NewDiffRowSink(threshold int) *DiffRowSink {
+	if threshold <= 0 {
+		threshold = defaultSpillThreshold
+	}
+	return &DiffRowSink{
+		threshold: threshold,
+	}
+}
+
+// Append adds a row to the sink. If the in-memory buffer is full, it is
+// flushed to a temporary spill file on disk.
+func (s *DiffRowSink) Append(row types.OrderedMap) error {
+	s.rows = append(s.rows, row)
+	s.count++
+
+	if len(s.rows) >= s.threshold {
+		return s.flush()
+	}
+	return nil
+}
+
+// Len returns the total number of rows (in-memory + spilled).
+func (s *DiffRowSink) Len() int {
+	return s.count
+}
+
+// Iterate calls fn for every row in insertion order: spilled rows first,
+// then in-memory rows.
+func (s *DiffRowSink) Iterate(fn func(types.OrderedMap) error) error {
+	if err := s.iterateSpillFile(fn); err != nil {
+		return err
+	}
+	for _, row := range s.rows {
+		if err := fn(row); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// SortedIterate loads all rows (spill + memory) into a temporary slice,
+// sorts by primary key, calls fn for each row, then releases the slice.
+func (s *DiffRowSink) SortedIterate(pk []string, fn func(types.OrderedMap) error) error {
+	all := make([]types.OrderedMap, 0, s.count)
+
+	if err := s.iterateSpillFile(func(row types.OrderedMap) error {
+		all = append(all, row)
+		return nil
+	}); err != nil {
+		return err
+	}
+	all = append(all, s.rows...)
+
+	sort.SliceStable(all, func(i, j int) bool {
+		pkI := getPKValues(all[i], pk)
+		pkJ := getPKValues(all[j], pk)
+		return comparePKValues(pkI, pkJ) < 0
+	})
+
+	for _, row := range all {
+		if err := fn(row); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Close removes the spill file (if any) and releases in-memory rows.
+func (s *DiffRowSink) Close() {
+	s.rows = nil
+	if s.spillFile != nil {
+		name := s.spillFile.Name()
+		s.spillFile.Close()
+		os.Remove(name)
+		s.spillFile = nil
+	}
+}
+
+// flush writes the in-memory buffer to the spill file and resets it.
+func (s *DiffRowSink) flush() error {
+	if s.spillFile == nil {
+		f, err := os.CreateTemp("", "ace-diff-spill-*.ndjson")
+		if err != nil {
+			return fmt.Errorf("failed to create diff spill file: %w", err)
+		}
+		s.spillFile = f
+	}
+
+	enc := json.NewEncoder(s.spillFile)
+	for _, row := range s.rows {
+		if err := enc.Encode(row); err != nil {
+			return fmt.Errorf("failed to write to diff spill file: %w", err)
+		}
+	}
+	s.spilled += len(s.rows)
+	s.rows = s.rows[:0]
+	return nil
+}
+
+// iterateSpillFile reads the spill file from the beginning and calls fn
+// for each row. If no spill file exists, this is a no-op.
+func (s *DiffRowSink) iterateSpillFile(fn func(types.OrderedMap) error) error {
+	if s.spillFile == nil || s.spilled == 0 {
+		return nil
+	}
+
+	if _, err := s.spillFile.Seek(0, 0); err != nil {
+		return fmt.Errorf("failed to seek diff spill file: %w", err)
+	}
+
+	scanner := bufio.NewScanner(s.spillFile)
+	scanner.Buffer(make([]byte, 0, 256*1024), 10*1024*1024)
+	for scanner.Scan() {
+		var row types.OrderedMap
+		if err := json.Unmarshal(scanner.Bytes(), &row); err != nil {
+			return fmt.Errorf("failed to decode spill row: %w", err)
+		}
+		if err := fn(row); err != nil {
+			return err
+		}
+	}
+	return scanner.Err()
+}
+
+// DiffSinks maps pairKey -> nodeName -> *DiffRowSink. It is held on the task
+// struct (TableDiffTask.diffSinks, MerkleTreeTask.diffSinks) during a diff run
+// and passed to WriteDiffReport for streaming the sorted JSON output.
+type DiffSinks map[string]map[string]*DiffRowSink
+
+// GetSink returns the sink for the given pair and node, creating it if needed.
+func (ds DiffSinks) GetSink(pairKey, nodeName string, threshold int) *DiffRowSink {
+	nodeMap, ok := ds[pairKey]
+	if !ok {
+		nodeMap = make(map[string]*DiffRowSink)
+		ds[pairKey] = nodeMap
+	}
+	sink, ok := nodeMap[nodeName]
+	if !ok {
+		sink = NewDiffRowSink(threshold)
+		nodeMap[nodeName] = sink
+	}
+	return sink
+}
+
+// getSink returns the sink for the given pair and node, or nil if not present.
+func (ds DiffSinks) getSink(pairKey, nodeName string) *DiffRowSink {
+	if ds == nil {
+		return nil
+	}
+	if nodeMap, ok := ds[pairKey]; ok {
+		return nodeMap[nodeName]
+	}
+	return nil
+}
+
+// CloseAll closes and removes all sinks.
+func (ds DiffSinks) CloseAll() {
+	for _, nodeMap := range ds {
+		for _, sink := range nodeMap {
+			sink.Close()
+		}
+	}
+}

--- a/pkg/common/diff_sink_test.go
+++ b/pkg/common/diff_sink_test.go
@@ -1,0 +1,136 @@
+package common
+
+import (
+	"os"
+	"testing"
+
+	"github.com/pgedge/ace/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func makeTestRow(id int) types.OrderedMap {
+	return types.OrderedMap{
+		{Key: "id", Value: float64(id)},
+		{Key: "name", Value: "row"},
+	}
+}
+
+func TestDiffRowSink_NoSpill(t *testing.T) {
+	s := NewDiffRowSink(100)
+	defer s.Close()
+
+	for i := 0; i < 50; i++ {
+		require.NoError(t, s.Append(makeTestRow(i)))
+	}
+
+	require.Equal(t, 50, s.Len())
+	require.Nil(t, s.spillFile, "should not spill when below threshold")
+
+	var collected []types.OrderedMap
+	require.NoError(t, s.Iterate(func(row types.OrderedMap) error {
+		collected = append(collected, row)
+		return nil
+	}))
+	require.Len(t, collected, 50)
+	// Verify insertion order.
+	for i, row := range collected {
+		require.Equal(t, float64(i), row[0].Value)
+	}
+}
+
+func TestDiffRowSink_Spill(t *testing.T) {
+	s := NewDiffRowSink(10) // very low threshold
+	defer s.Close()
+
+	for i := 0; i < 35; i++ {
+		require.NoError(t, s.Append(makeTestRow(i)))
+	}
+
+	require.Equal(t, 35, s.Len())
+	require.NotNil(t, s.spillFile, "should have spilled to disk")
+	require.Equal(t, 30, s.spilled, "3 full batches of 10 should be spilled")
+	require.Len(t, s.rows, 5, "5 rows should remain in memory")
+
+	// Iterate should return all 35 rows in insertion order.
+	var collected []types.OrderedMap
+	require.NoError(t, s.Iterate(func(row types.OrderedMap) error {
+		collected = append(collected, row)
+		return nil
+	}))
+	require.Len(t, collected, 35)
+	for i, row := range collected {
+		require.Equal(t, float64(i), row[0].Value)
+	}
+}
+
+func TestDiffRowSink_SortedIterate(t *testing.T) {
+	s := NewDiffRowSink(5)
+	defer s.Close()
+
+	// Insert rows in reverse order to verify sorting.
+	for i := 19; i >= 0; i-- {
+		require.NoError(t, s.Append(makeTestRow(i)))
+	}
+
+	require.Equal(t, 20, s.Len())
+	require.NotNil(t, s.spillFile)
+
+	var ids []float64
+	require.NoError(t, s.SortedIterate([]string{"id"}, func(row types.OrderedMap) error {
+		ids = append(ids, row[0].Value.(float64))
+		return nil
+	}))
+
+	require.Len(t, ids, 20)
+	for i, id := range ids {
+		require.Equal(t, float64(i), id, "row %d should have id %d", i, i)
+	}
+}
+
+func TestDiffRowSink_Close_RemovesFile(t *testing.T) {
+	s := NewDiffRowSink(5)
+
+	for i := 0; i < 10; i++ {
+		require.NoError(t, s.Append(makeTestRow(i)))
+	}
+	require.NotNil(t, s.spillFile)
+	path := s.spillFile.Name()
+
+	s.Close()
+
+	_, err := os.Stat(path)
+	require.True(t, os.IsNotExist(err), "spill file should be removed after Close")
+}
+
+func TestDiffSinks_GetSink(t *testing.T) {
+	ds := make(DiffSinks)
+
+	s1 := ds.GetSink("n1/n2", "n1", 100)
+	s2 := ds.GetSink("n1/n2", "n2", 100)
+	s3 := ds.GetSink("n1/n2", "n1", 100) // same as s1
+
+	require.Same(t, s1, s3, "should return the same sink for same pair+node")
+	require.NotSame(t, s1, s2, "different nodes should get different sinks")
+}
+
+func TestDiffSinks_CloseAll(t *testing.T) {
+	ds := make(DiffSinks)
+	s1 := ds.GetSink("n1/n2", "n1", 5)
+	s2 := ds.GetSink("n1/n2", "n2", 5)
+
+	// Force spill on both.
+	for i := 0; i < 10; i++ {
+		require.NoError(t, s1.Append(makeTestRow(i)))
+		require.NoError(t, s2.Append(makeTestRow(i)))
+	}
+
+	path1 := s1.spillFile.Name()
+	path2 := s2.spillFile.Name()
+
+	ds.CloseAll()
+
+	_, err := os.Stat(path1)
+	require.True(t, os.IsNotExist(err))
+	_, err = os.Stat(path2)
+	require.True(t, os.IsNotExist(err))
+}

--- a/pkg/common/html_reporter.go
+++ b/pkg/common/html_reporter.go
@@ -42,14 +42,20 @@ type htmlPairCount struct {
 	Count string
 }
 
-func writeHTMLDiffReport(diffResult types.DiffOutput, jsonFilePath string) (string, error) {
+func writeHTMLDiffReport(jsonFilePath string) (string, error) {
 	if jsonFilePath == "" {
 		return "", nil
 	}
 
-	rawJSON, err := json.Marshal(diffResult)
+	// Read the already-written JSON file instead of re-marshaling the struct.
+	rawJSON, err := os.ReadFile(jsonFilePath)
 	if err != nil {
-		return "", fmt.Errorf("failed to marshal diff result for HTML embedding: %w", err)
+		return "", fmt.Errorf("failed to read diff JSON for HTML embedding: %w", err)
+	}
+
+	var diffResult types.DiffOutput
+	if err := json.Unmarshal(rawJSON, &diffResult); err != nil {
+		return "", fmt.Errorf("failed to parse diff JSON for HTML report: %w", err)
 	}
 
 	htmlPath := strings.TrimSuffix(jsonFilePath, filepath.Ext(jsonFilePath)) + ".html"

--- a/pkg/common/stream_json_test.go
+++ b/pkg/common/stream_json_test.go
@@ -1,0 +1,302 @@
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/pgedge/ace/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+// makeRow builds a single OrderedMap row with an id and nCols text columns,
+// each ~valLen bytes, simulating JSONB-heavy table data.
+func makeRow(id int, nCols int, valLen int) types.OrderedMap {
+	row := types.OrderedMap{{Key: "id", Value: id}}
+	payload := make([]byte, valLen)
+	for i := range payload {
+		payload[i] = 'x'
+	}
+	s := string(payload)
+	for c := 0; c < nCols; c++ {
+		row = append(row, types.KVPair{Key: fmt.Sprintf("col_%d", c), Value: s})
+	}
+	return row
+}
+
+// buildLargeDiff creates a DiffOutput with the given number of node-pair
+// blocks, rows per block, columns per row, and bytes per column value.
+func buildLargeDiff(nPairs, rowsPerNode, cols, valLen int) types.DiffOutput {
+	diffs := make(map[string]types.DiffByNodePair, nPairs)
+	for p := 0; p < nPairs; p++ {
+		n1 := fmt.Sprintf("n%d", p*2+1)
+		n2 := fmt.Sprintf("n%d", p*2+2)
+		key := n1 + "/" + n2
+
+		rows1 := make([]types.OrderedMap, rowsPerNode)
+		rows2 := make([]types.OrderedMap, rowsPerNode)
+		for i := 0; i < rowsPerNode; i++ {
+			rows1[i] = makeRow(i, cols, valLen)
+			rows2[i] = makeRow(i, cols, valLen)
+		}
+		diffs[key] = types.DiffByNodePair{
+			Rows: map[string][]types.OrderedMap{
+				n1: rows1,
+				n2: rows2,
+			},
+		}
+	}
+
+	return types.DiffOutput{
+		NodeDiffs: diffs,
+		Summary: types.DiffSummary{
+			Schema:     "public",
+			Table:      "large_test",
+			Nodes:      []string{"n1", "n2"},
+			BlockSize:  1000,
+			PrimaryKey: []string{"id"},
+			DiffRowsCount: map[string]int{
+				"n1/n2": rowsPerNode,
+			},
+		},
+	}
+}
+
+func currentHeapMB() float64 {
+	runtime.GC()
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	return float64(m.HeapAlloc) / (1024 * 1024)
+}
+
+// TestStreamDiffJSON_LargeOutput verifies that streamDiffJSON produces valid
+// JSON and that peak heap growth stays well below the serialised JSON size.
+// It also measures the old json.NewEncoder.Encode approach for comparison.
+func TestStreamDiffJSON_LargeOutput(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping large-memory streaming test in short mode")
+	}
+
+	const (
+		nPairs      = 10
+		rowsPerNode = 5000
+		cols        = 5
+		valLen      = 200
+	)
+
+	dir := t.TempDir()
+
+	// --- old approach: json.NewEncoder.Encode (buffers everything) ---
+	diff := buildLargeDiff(nPairs, rowsPerNode, cols, valLen)
+	baselineOld := currentHeapMB()
+	t.Logf("[old] baseline heap: %.1f MB", baselineOld)
+
+	oldPath := filepath.Join(dir, "old.json")
+	startOld := time.Now()
+	f, err := os.Create(oldPath)
+	require.NoError(t, err)
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "  ")
+	err = enc.Encode(diff)
+	require.NoError(t, err)
+	f.Close()
+	elapsedOld := time.Since(startOld)
+
+	peakOld := currentHeapMB()
+	growthOld := peakOld - baselineOld
+	fiOld, _ := os.Stat(oldPath)
+	t.Logf("[old] heap after Encode: %.1f MB (growth: %.1f MB), time: %v", peakOld, growthOld, elapsedOld)
+	t.Logf("[old] output file size: %.1f MB", float64(fiOld.Size())/(1024*1024))
+
+	// Free the old output so it doesn't skew the streaming measurement.
+	diff = types.DiffOutput{}
+	runtime.GC()
+
+	// --- new approach: streamDiffJSON (row-at-a-time, in-memory Rows) ---
+	diff = buildLargeDiff(nPairs, rowsPerNode, cols, valLen)
+	baselineNew := currentHeapMB()
+	t.Logf("[new] baseline heap: %.1f MB", baselineNew)
+
+	newPath := filepath.Join(dir, "new.json")
+	startNew := time.Now()
+	err = streamDiffJSON(newPath, diff, nil)
+	require.NoError(t, err)
+	elapsedNew := time.Since(startNew)
+
+	peakNew := currentHeapMB()
+	growthNew := peakNew - baselineNew
+	fiNew, _ := os.Stat(newPath)
+	t.Logf("[new] heap after streamDiffJSON: %.1f MB (growth: %.1f MB), time: %v", peakNew, growthNew, elapsedNew)
+	t.Logf("[new] output file size: %.1f MB", float64(fiNew.Size())/(1024*1024))
+
+	// Free before sink test.
+	diff = types.DiffOutput{}
+	runtime.GC()
+
+	// --- sink approach: accumulate via DiffRowSinks with small spill threshold ---
+	sinkThreshold := 500 // low threshold to exercise spill path
+	sinks := make(DiffSinks)
+	sinkDiff := types.DiffOutput{
+		NodeDiffs: make(map[string]types.DiffByNodePair),
+		Summary: types.DiffSummary{
+			Schema:     "public",
+			Table:      "large_test",
+			PrimaryKey: []string{"id"},
+			DiffRowsCount: make(map[string]int),
+		},
+	}
+
+	// Simulate what table_diff does: append rows one at a time into sinks.
+	// Time includes both accumulation (with spilling) and writing.
+	startSinkAccum := time.Now()
+	for p := 0; p < nPairs; p++ {
+		n1 := fmt.Sprintf("n%d", p*2+1)
+		n2 := fmt.Sprintf("n%d", p*2+2)
+		pairKey := n1 + "/" + n2
+		sinkDiff.NodeDiffs[pairKey] = types.DiffByNodePair{
+			Rows: make(map[string][]types.OrderedMap),
+		}
+		sink1 := sinks.GetSink(pairKey, n1, sinkThreshold)
+		sink2 := sinks.GetSink(pairKey, n2, sinkThreshold)
+		for i := 0; i < rowsPerNode; i++ {
+			row := makeRow(i, cols, valLen)
+			require.NoError(t, sink1.Append(row))
+			require.NoError(t, sink2.Append(row))
+		}
+	}
+	elapsedSinkAccum := time.Since(startSinkAccum)
+
+	baselineSink := currentHeapMB()
+	t.Logf("[sink] baseline heap after accumulation: %.1f MB, accumulation time: %v", baselineSink, elapsedSinkAccum)
+
+	sinkPath := filepath.Join(dir, "sink.json")
+	startSinkWrite := time.Now()
+	err = streamDiffJSON(sinkPath, sinkDiff, sinks)
+	require.NoError(t, err)
+	elapsedSinkWrite := time.Since(startSinkWrite)
+	sinks.CloseAll()
+
+	peakSink := currentHeapMB()
+	growthSink := peakSink - baselineSink
+	fiSink, _ := os.Stat(sinkPath)
+	t.Logf("[sink] heap after streamDiffJSON: %.1f MB (growth: %.1f MB), write time: %v", peakSink, growthSink, elapsedSinkWrite)
+	t.Logf("[sink] output file size: %.1f MB", float64(fiSink.Size())/(1024*1024))
+
+	t.Logf("--- summary ---")
+	t.Logf("old Encode     heap growth: %+6.1f MB   time: %v", growthOld, elapsedOld)
+	t.Logf("new stream     heap growth: %+6.1f MB   time: %v", growthNew, elapsedNew)
+	t.Logf("sink accum+write           %+6.1f MB   time: %v (accum: %v, write: %v)",
+		growthSink, elapsedSinkAccum+elapsedSinkWrite, elapsedSinkAccum, elapsedSinkWrite)
+
+	// The streaming approach should use significantly less additional memory.
+	require.Less(t, growthNew, 50.0,
+		"streaming writer heap growth should be well under 50 MB; got %.1f MB", growthNew)
+
+	// Validate the sink output is legal JSON and round-trips correctly.
+	data, err := os.ReadFile(sinkPath)
+	require.NoError(t, err)
+
+	var parsed types.DiffOutput
+	require.NoError(t, json.Unmarshal(data, &parsed), "output must be valid JSON")
+
+	require.Len(t, parsed.NodeDiffs, nPairs)
+	for _, pair := range parsed.NodeDiffs {
+		for _, rows := range pair.Rows {
+			require.Len(t, rows, rowsPerNode)
+		}
+	}
+	require.Equal(t, "public", parsed.Summary.Schema)
+	require.Equal(t, "large_test", parsed.Summary.Table)
+}
+
+// TestStreamDiffJSON_Empty verifies empty diffs produce valid JSON.
+func TestStreamDiffJSON_Empty(t *testing.T) {
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "empty.json")
+
+	diff := types.DiffOutput{
+		NodeDiffs: map[string]types.DiffByNodePair{},
+		Summary: types.DiffSummary{
+			Schema: "public",
+			Table:  "empty_test",
+		},
+	}
+
+	require.NoError(t, streamDiffJSON(outPath, diff, nil))
+
+	data, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+
+	var parsed types.DiffOutput
+	require.NoError(t, json.Unmarshal(data, &parsed))
+	require.Empty(t, parsed.NodeDiffs)
+	require.Equal(t, "public", parsed.Summary.Schema)
+}
+
+// TestStreamDiffJSON_WithSinks verifies the full pipeline: rows accumulated
+// in DiffRowSinks (with a small spill threshold) produce valid, sorted JSON.
+func TestStreamDiffJSON_WithSinks(t *testing.T) {
+	const (
+		spillThreshold = 3 // very small to force spilling
+		totalRows      = 20
+	)
+
+	// Build sinks with rows in reverse PK order to verify sorting.
+	sinks := make(DiffSinks)
+	sink1 := sinks.GetSink("n1/n2", "n1", spillThreshold)
+	sink2 := sinks.GetSink("n1/n2", "n2", spillThreshold)
+	for i := totalRows - 1; i >= 0; i-- {
+		row := types.OrderedMap{
+			{Key: "id", Value: float64(i)},
+			{Key: "val", Value: fmt.Sprintf("data_%d", i)},
+		}
+		require.NoError(t, sink1.Append(row))
+		require.NoError(t, sink2.Append(row))
+	}
+	defer sinks.CloseAll()
+
+	require.NotNil(t, sink1.spillFile, "sink1 should have spilled")
+	require.NotNil(t, sink2.spillFile, "sink2 should have spilled")
+
+	// DiffResult has the pair entry (for NodeDiffs key iteration) but empty Rows.
+	diff := types.DiffOutput{
+		NodeDiffs: map[string]types.DiffByNodePair{
+			"n1/n2": {Rows: make(map[string][]types.OrderedMap)},
+		},
+		Summary: types.DiffSummary{
+			Schema:     "public",
+			Table:      "sink_test",
+			PrimaryKey: []string{"id"},
+			DiffRowsCount: map[string]int{"n1/n2": totalRows},
+		},
+	}
+
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "sink_test.json")
+	require.NoError(t, streamDiffJSON(outPath, diff, sinks))
+
+	// Parse and validate.
+	data, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+
+	var parsed types.DiffOutput
+	require.NoError(t, json.Unmarshal(data, &parsed), "output must be valid JSON")
+
+	require.Len(t, parsed.NodeDiffs, 1)
+	pair := parsed.NodeDiffs["n1/n2"]
+	require.Len(t, pair.Rows["n1"], totalRows)
+	require.Len(t, pair.Rows["n2"], totalRows)
+
+	// Verify rows are sorted by PK ascending (not reverse insertion order).
+	for _, nodeKey := range []string{"n1", "n2"} {
+		rows := pair.Rows[nodeKey]
+		for i, row := range rows {
+			require.Equal(t, float64(i), row[0].Value,
+				"node %s row %d should have id %d (sorted)", nodeKey, i, i)
+		}
+	}
+}

--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -1192,20 +1192,23 @@ func MapToOrderedMap(m map[string]any, cols []string) types.OrderedMap {
 	return om
 }
 
-func WriteDiffReport(diffResult types.DiffOutput, schema, table, format string) (string, string, error) {
-	if len(diffResult.NodeDiffs) == 0 {
+func WriteDiffReport(diffResult types.DiffOutput, sinks DiffSinks, schema, table, format string) (string, string, error) {
+	if len(diffResult.NodeDiffs) == 0 && len(sinks) == 0 {
 		logger.Info("%s TABLES MATCH", CheckMark)
 		return "", "", nil
 	}
 
-	for _, nodePairDiff := range diffResult.NodeDiffs {
-		for nodeName, rows := range nodePairDiff.Rows {
-			sort.SliceStable(rows, func(i, j int) bool {
-				pkValuesI := getPKValues(rows[i], diffResult.Summary.PrimaryKey)
-				pkValuesJ := getPKValues(rows[j], diffResult.Summary.PrimaryKey)
-				return comparePKValues(pkValuesI, pkValuesJ) < 0
-			})
-			nodePairDiff.Rows[nodeName] = rows
+	// When sinks are nil (e.g. rerun path), sort the in-memory Rows as before.
+	if sinks == nil {
+		for _, nodePairDiff := range diffResult.NodeDiffs {
+			for nodeName, rows := range nodePairDiff.Rows {
+				sort.SliceStable(rows, func(i, j int) bool {
+					pkValuesI := getPKValues(rows[i], diffResult.Summary.PrimaryKey)
+					pkValuesJ := getPKValues(rows[j], diffResult.Summary.PrimaryKey)
+					return comparePKValues(pkValuesI, pkValuesJ) < 0
+				})
+				nodePairDiff.Rows[nodeName] = rows
+			}
 		}
 	}
 
@@ -1216,22 +1219,9 @@ func WriteDiffReport(diffResult types.DiffOutput, schema, table, format string) 
 	)
 	jsonFileName := outputPrefix + ".json"
 
-	// Stream JSON directly to file — avoids holding a second full copy in memory
-	f, err := os.Create(jsonFileName)
-	if err != nil {
-		logger.Error("ERROR creating diff output file %s: %v", jsonFileName, err)
-		return "", "", fmt.Errorf("failed to create diffs file: %w", err)
-	}
-	enc := json.NewEncoder(f)
-	enc.SetIndent("", "  ")
-	if err := enc.Encode(diffResult); err != nil {
-		logger.Error("ERROR writing diff output to JSON: %v", err)
-		f.Close()
-		return "", "", fmt.Errorf("failed to write diffs: %w", err)
-	}
-	if err := f.Close(); err != nil {
-		logger.Error("ERROR closing diff output file %s: %v", jsonFileName, err)
-		return "", "", fmt.Errorf("failed to close diffs file: %w", err)
+	// Stream JSON to file one row at a time so we never buffer the full report.
+	if err := streamDiffJSON(jsonFileName, diffResult, sinks); err != nil {
+		return "", "", err
 	}
 
 	logger.Warn("%s TABLES DO NOT MATCH", CrossMark)
@@ -1242,7 +1232,7 @@ func WriteDiffReport(diffResult types.DiffOutput, schema, table, format string) 
 
 	var htmlPath string
 	if strings.EqualFold(format, "html") {
-		htmlPath, err = writeHTMLDiffReport(diffResult, jsonFileName)
+		htmlPath, err := writeHTMLDiffReport(jsonFileName)
 		if err != nil {
 			return "", "", err
 		}
@@ -1252,6 +1242,161 @@ func WriteDiffReport(diffResult types.DiffOutput, schema, table, format string) 
 	}
 
 	return jsonFileName, htmlPath, nil
+}
+
+// streamDiffJSON writes the DiffOutput as JSON to the given file, streaming
+// one row at a time so that the entire serialised report is never in memory.
+// When sinks is non-nil, rows are read from sinks (sorted by PK) instead of
+// diff.NodeDiffs[...].Rows.
+func streamDiffJSON(path string, diff types.DiffOutput, sinks DiffSinks) error {
+	f, err := os.Create(path)
+	if err != nil {
+		logger.Error("ERROR creating diff output file %s: %v", path, err)
+		return fmt.Errorf("failed to create diffs file: %w", err)
+	}
+	defer func() {
+		if f != nil {
+			f.Close()
+		}
+	}()
+
+	w := bufio.NewWriterSize(f, 256*1024)
+
+	// Helper: write a literal string.
+	ws := func(s string) error { _, err := w.WriteString(s); return err }
+
+	// writeRow writes a single JSON-encoded row preceded by a comma if needed.
+	writeRow := func(row types.OrderedMap, first *bool) error {
+		if !*first {
+			if err := ws(","); err != nil {
+				return err
+			}
+		}
+		*first = false
+		rowJSON, err := json.Marshal(row)
+		if err != nil {
+			return fmt.Errorf("failed to marshal row: %w", err)
+		}
+		if err := ws("\n        "); err != nil {
+			return err
+		}
+		_, err = w.Write(rowJSON)
+		return err
+	}
+
+	// Collect pair keys from both NodeDiffs and sinks for deterministic output.
+	pairKeySet := make(map[string]struct{})
+	for k := range diff.NodeDiffs {
+		pairKeySet[k] = struct{}{}
+	}
+	for k := range sinks {
+		pairKeySet[k] = struct{}{}
+	}
+	pairKeys := make([]string, 0, len(pairKeySet))
+	for k := range pairKeySet {
+		pairKeys = append(pairKeys, k)
+	}
+	sort.Strings(pairKeys)
+
+	// --- open root object and "diffs" key ---
+	if err := ws("{\n  \"diffs\": {"); err != nil {
+		return err
+	}
+
+	for pairIdx, pairKey := range pairKeys {
+		if pairIdx > 0 {
+			if err := ws(","); err != nil {
+				return err
+			}
+		}
+
+		keyJSON, _ := json.Marshal(pairKey)
+		if err := ws("\n    " + string(keyJSON) + ": {\"rows\": {"); err != nil {
+			return err
+		}
+
+		// Collect node keys from Rows and/or sinks for this pair.
+		nodeKeySet := make(map[string]struct{})
+		if pair, ok := diff.NodeDiffs[pairKey]; ok {
+			for k := range pair.Rows {
+				nodeKeySet[k] = struct{}{}
+			}
+		}
+		if sinkNodes, ok := sinks[pairKey]; ok {
+			for k := range sinkNodes {
+				nodeKeySet[k] = struct{}{}
+			}
+		}
+		nodeKeys := make([]string, 0, len(nodeKeySet))
+		for k := range nodeKeySet {
+			nodeKeys = append(nodeKeys, k)
+		}
+		sort.Strings(nodeKeys)
+
+		for nodeIdx, nodeKey := range nodeKeys {
+			if nodeIdx > 0 {
+				if err := ws(","); err != nil {
+					return err
+				}
+			}
+
+			nkJSON, _ := json.Marshal(nodeKey)
+			if err := ws("\n      " + string(nkJSON) + ": ["); err != nil {
+				return err
+			}
+
+			first := true
+			if sink := sinks.getSink(pairKey, nodeKey); sink != nil && sink.Len() > 0 {
+				// Write from sink, sorted by PK.
+				if err := sink.SortedIterate(diff.Summary.PrimaryKey, func(row types.OrderedMap) error {
+					return writeRow(row, &first)
+				}); err != nil {
+					return err
+				}
+			} else if pair, ok := diff.NodeDiffs[pairKey]; ok {
+				// Fallback: write from in-memory Rows (already sorted by caller).
+				for _, row := range pair.Rows[nodeKey] {
+					if err := writeRow(row, &first); err != nil {
+						return err
+					}
+				}
+			}
+
+			if err := ws("\n      ]"); err != nil {
+				return err
+			}
+		}
+
+		if err := ws("\n    }}"); err != nil {
+			return err
+		}
+	}
+
+	// --- close "diffs", write "summary" ---
+	if err := ws("\n  },\n  \"summary\": "); err != nil {
+		return err
+	}
+	summaryJSON, err := json.MarshalIndent(diff.Summary, "  ", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal summary: %w", err)
+	}
+	if _, err := w.Write(summaryJSON); err != nil {
+		return err
+	}
+	if err := ws("\n}\n"); err != nil {
+		return err
+	}
+
+	if err := w.Flush(); err != nil {
+		return fmt.Errorf("failed to flush diffs file: %w", err)
+	}
+	err = f.Close()
+	f = nil // prevent double close in defer
+	if err != nil {
+		logger.Error("ERROR closing diff output file %s: %v", path, err)
+		return fmt.Errorf("failed to close diffs file: %w", err)
+	}
+	return nil
 }
 
 func getPKValues(row types.OrderedMap, pkey []string) []any {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -54,6 +54,7 @@ type DiffConfig struct {
 	BatchSize         int     `yaml:"diff_batch_size"`
 	MaxBatchSize      int     `yaml:"max_diff_batch_size"`
 	CompareUnitSize   int     `yaml:"compare_unit_size"`
+	DiffSpillThreshold int    `yaml:"diff_spill_threshold"`
 }
 
 type MTreeConfig struct {


### PR DESCRIPTION
During table-diff and mtree-diff, all differing rows were held in memory in DiffResult.NodeDiffs. For large diffs (e.g. 250K+ rows with JSONB data) this alone could exhaust available memory before the report was even written. Additionally, json.NewEncoder.Encode still buffered the entire JSON output in memory before writing.

Introduce DiffRowSink, which buffers rows in memory up to a configurable threshold (default 10K per sink) then spills overflow to a temporary NDJSON file. At report time each sink's rows are loaded back one sink at a time, sorted by PK, and streamed to the output JSON one row at a time through a buffered writer. Downstream consumers (repair, rerun) read from the JSON file and are unaffected.

Also fix the HTML reporter to read the already-written JSON file instead of re-marshaling the entire DiffOutput struct.