### PR TITLE
Fix precision loss for large bigint PKs in table repair JSON roundtrip

### DIFF
--- a/internal/consistency/repair/executor.go
+++ b/internal/consistency/repair/executor.go
@@ -286,10 +286,8 @@ func pkMatchesOverride(pkOrder []string, rowPk map[string]any, overridePk map[st
 	}
 
 	equal := func(a, b any) bool {
-		if af, ok := asFloat(a); ok {
-			if bf, ok2 := asFloat(b); ok2 {
-				return af == bf
-			}
+		if cmp, ok := utils.CompareNumeric(a, b); ok {
+			return cmp == 0
 		}
 		return reflect.DeepEqual(a, b)
 	}
@@ -308,10 +306,8 @@ func matchPKIn(matchers []planner.RepairPKMatcher, rowPk map[string]any, pkOrder
 	}
 
 	equal := func(a, b any) bool {
-		if af, ok := asFloat(a); ok {
-			if bf, ok2 := asFloat(b); ok2 {
-				return af == bf
-			}
+		if cmp, ok := utils.CompareNumeric(a, b); ok {
+			return cmp == 0
 		}
 		return reflect.DeepEqual(a, b)
 	}
@@ -353,11 +349,10 @@ func matchPKIn(matchers []planner.RepairPKMatcher, rowPk map[string]any, pkOrder
 }
 
 func compareRange(val, from, to any) bool {
-	ln, lok := asFloat(val)
-	fn, fok := asFloat(from)
-	tn, tok := asFloat(to)
-	if lok && fok && tok {
-		return ln >= fn && ln <= tn
+	cmpFrom, okFrom := utils.CompareNumeric(val, from)
+	cmpTo, okTo := utils.CompareNumeric(val, to)
+	if okFrom && okTo {
+		return cmpFrom >= 0 && cmpTo <= 0
 	}
 
 	ls, lsok := val.(string)
@@ -367,37 +362,6 @@ func compareRange(val, from, to any) bool {
 		return ls >= fs && ls <= ts
 	}
 	return false
-}
-
-func asFloat(v any) (float64, bool) {
-	switch n := v.(type) {
-	case int:
-		return float64(n), true
-	case int8:
-		return float64(n), true
-	case int16:
-		return float64(n), true
-	case int32:
-		return float64(n), true
-	case int64:
-		return float64(n), true
-	case uint:
-		return float64(n), true
-	case uint8:
-		return float64(n), true
-	case uint16:
-		return float64(n), true
-	case uint32:
-		return float64(n), true
-	case uint64:
-		return float64(n), true
-	case float32:
-		return float64(n), true
-	case float64:
-		return n, true
-	default:
-		return 0, false
-	}
 }
 
 func columnsIntersect(a, b []string) bool {
@@ -780,15 +744,13 @@ func freshestSide(key string, tie string, row planDiffRow) string {
 		return strings.TrimSpace(strings.ToLower(tie))
 	}
 
-	if f1, ok := asFloat(k1); ok {
-		if f2, ok2 := asFloat(k2); ok2 {
-			if f1 > f2 {
-				return "n1"
-			} else if f2 > f1 {
-				return "n2"
-			}
-			return strings.TrimSpace(strings.ToLower(tie))
+	if cmp, ok := utils.CompareNumeric(k1, k2); ok {
+		if cmp > 0 {
+			return "n1"
+		} else if cmp < 0 {
+			return "n2"
 		}
+		return strings.TrimSpace(strings.ToLower(tie))
 	}
 
 	if s1, ok := k1.(string); ok {

--- a/internal/consistency/repair/plan/parser/parser.go
+++ b/internal/consistency/repair/plan/parser/parser.go
@@ -231,11 +231,8 @@ func (l *lexer) scanNumber() (token, error) {
 	text := l.input[start:l.pos]
 	// Store as json.Number to preserve full precision for large integers
 	// and high-precision decimals. CompareNumeric handles json.Number natively.
-	n := json.Number(text)
-	if _, err := n.Float64(); err != nil {
-		return token{}, fmt.Errorf("invalid number %q at pos %d", text, start)
-	}
-	return token{typ: tokNumber, lit: text, pos: start, value: n}, nil
+	// Syntax is already validated by the character-by-character scan above.
+	return token{typ: tokNumber, lit: text, pos: start, value: json.Number(text)}, nil
 }
 
 func (l *lexer) scanIdent() (token, error) {

--- a/internal/consistency/repair/plan/parser/parser.go
+++ b/internal/consistency/repair/plan/parser/parser.go
@@ -12,10 +12,12 @@
 package parser
 
 import (
+	"encoding/json"
 	"fmt"
-	"strconv"
 	"strings"
 	"unicode"
+
+	utils "github.com/pgedge/ace/pkg/common"
 )
 
 // WhenExpr represents a compiled predicate over diff row values (n1./n2.).
@@ -227,11 +229,13 @@ func (l *lexer) scanNumber() (token, error) {
 		l.pos++
 	}
 	text := l.input[start:l.pos]
-	num, err := strconv.ParseFloat(text, 64)
-	if err != nil {
+	// Store as json.Number to preserve full precision for large integers
+	// and high-precision decimals. CompareNumeric handles json.Number natively.
+	n := json.Number(text)
+	if _, err := n.Float64(); err != nil {
 		return token{}, fmt.Errorf("invalid number %q at pos %d", text, start)
 	}
-	return token{typ: tokNumber, lit: text, pos: start, value: num}, nil
+	return token{typ: tokNumber, lit: text, pos: start, value: n}, nil
 }
 
 func (l *lexer) scanIdent() (token, error) {
@@ -612,22 +616,20 @@ func compareValues(op tokenType, left any, right any) (bool, error) {
 		}
 	}
 
-	ln, lok := asNumber(left)
-	rn, rok := asNumber(right)
-	if lok && rok {
+	if cmp, ok := utils.CompareNumeric(left, right); ok {
 		switch op {
 		case tokEq:
-			return ln == rn, nil
+			return cmp == 0, nil
 		case tokNeq:
-			return ln != rn, nil
+			return cmp != 0, nil
 		case tokLt:
-			return ln < rn, nil
+			return cmp < 0, nil
 		case tokLte:
-			return ln <= rn, nil
+			return cmp <= 0, nil
 		case tokGt:
-			return ln > rn, nil
+			return cmp > 0, nil
 		case tokGte:
-			return ln >= rn, nil
+			return cmp >= 0, nil
 		default:
 			return false, fmt.Errorf("unsupported numeric operator %v", op)
 		}
@@ -670,33 +672,3 @@ func compareValues(op tokenType, left any, right any) (bool, error) {
 	return false, fmt.Errorf("cannot compare values of different or unsupported types (%T vs %T)", left, right)
 }
 
-func asNumber(v any) (float64, bool) {
-	switch n := v.(type) {
-	case int:
-		return float64(n), true
-	case int8:
-		return float64(n), true
-	case int16:
-		return float64(n), true
-	case int32:
-		return float64(n), true
-	case int64:
-		return float64(n), true
-	case uint:
-		return float64(n), true
-	case uint8:
-		return float64(n), true
-	case uint16:
-		return float64(n), true
-	case uint32:
-		return float64(n), true
-	case uint64:
-		return float64(n), true
-	case float32:
-		return float64(n), true
-	case float64:
-		return n, true
-	default:
-		return 0, false
-	}
-}

--- a/internal/consistency/repair/table_repair.go
+++ b/internal/consistency/repair/table_repair.go
@@ -2258,6 +2258,13 @@ func extractOriginInfoFromRow(row types.OrderedMap) *rowOriginInfo {
 			ts = parseNumericTimestamp(int64(v))
 		case float64:
 			ts = parseNumericTimestamp(int64(v))
+		case json.Number:
+			if i64, err := v.Int64(); err == nil {
+				ts = parseNumericTimestamp(i64)
+			} else {
+				logger.Warn("extractOriginInfoFromRow: failed to parse json.Number commit_ts %q: %v", v.String(), err)
+				return nil
+			}
 		default:
 			logger.Warn("extractOriginInfoFromRow: unhandled commit_ts type %T, skipping origin preservation", tsVal)
 			return nil

--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -20,9 +20,10 @@ import (
 	"fmt"
 	"log"
 	"maps"
+	"math"
+	"math/big"
 	"os"
 	"path/filepath"
-	"reflect"
 	"slices"
 	"sort"
 	"strconv"
@@ -544,8 +545,36 @@ func ConvertToPgxType(val any, pgType string) (any, error) {
 		return nil, fmt.Errorf("expected bool for %s, got %T", pgType, val)
 
 	case "smallint", "int2", "integer", "int", "int4", "bigint", "int8", "serial2", "serial4", "serial8":
-		// JSON numbers might unmarshal to float64. Need to handle this.
+		if n, ok := val.(json.Number); ok {
+			if i64, err := n.Int64(); err == nil {
+				return i64, nil
+			}
+			// Fallback for JSON strings like "42.0" (not produced by normal
+			// diff writes, but possible with manually edited files). Only
+			// accept values in float64's exact integer range (<=2^53) that
+			// are truly integral; reject fractional values like "42.5".
+			f, err := n.Float64()
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse json.Number %q as integer for %s: %w", n.String(), pgType, err)
+			}
+			const maxSafeInt = 1 << 53
+			if f > maxSafeInt || f < -maxSafeInt {
+				return nil, fmt.Errorf("json.Number %q exceeds safe integer range for float64-to-int64 conversion (%s)", n.String(), pgType)
+			}
+			if math.Trunc(f) != f {
+				return nil, fmt.Errorf("json.Number %q is not an integer for %s", n.String(), pgType)
+			}
+			return int64(f), nil
+		}
+
 		if f, ok := val.(float64); ok {
+			const maxSafeInt = 1 << 53
+			if f > maxSafeInt || f < -maxSafeInt {
+				return nil, fmt.Errorf("float64 %v exceeds safe integer range for %s", f, pgType)
+			}
+			if math.Trunc(f) != f {
+				return nil, fmt.Errorf("float64 %v is not an integer for %s", f, pgType)
+			}
 			return int64(f), nil
 		}
 
@@ -559,13 +588,46 @@ func ConvertToPgxType(val any, pgType string) (any, error) {
 
 		return nil, fmt.Errorf("expected integer type for %s, got %T", pgType, val)
 
-	case "real", "float4", "double precision", "float8", "numeric", "decimal":
+	case "real", "float4", "double precision", "float8":
+		if n, ok := val.(json.Number); ok {
+			f, err := n.Float64()
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse json.Number %q as float64 for %s: %w", n.String(), pgType, err)
+			}
+			return f, nil
+		}
+
 		if f, ok := val.(float64); ok {
 			return f, nil
 		}
 
-		// If we could not convert to float64, try to convert to string
-		// and use pgtype.Numeric
+		if s, ok := val.(string); ok {
+			f, err := strconv.ParseFloat(s, 64)
+			if err == nil {
+				return f, nil
+			}
+		}
+
+		return nil, fmt.Errorf("expected float type for %s, got %T", pgType, val)
+
+	case "numeric", "decimal":
+		if n, ok := val.(json.Number); ok {
+			num := pgtype.Numeric{}
+			if err := num.Set(n.String()); err == nil {
+				return &num, nil
+			}
+			// Fall back to float64 for simple values
+			f, err := n.Float64()
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse json.Number %q for %s: %w", n.String(), pgType, err)
+			}
+			return f, nil
+		}
+
+		if f, ok := val.(float64); ok {
+			return f, nil
+		}
+
 		if s, ok := val.(string); ok {
 			num := pgtype.Numeric{}
 			if err := num.Set(s); err == nil {
@@ -573,7 +635,7 @@ func ConvertToPgxType(val any, pgType string) (any, error) {
 			}
 		}
 
-		return nil, fmt.Errorf("expected float/numeric type for %s, got %T", pgType, val)
+		return nil, fmt.Errorf("expected numeric type for %s, got %T", pgType, val)
 
 	case "text", "varchar", "character varying", "char", "character", "bpchar", "name", "citext":
 		if s, ok := val.(string); ok {
@@ -1282,22 +1344,11 @@ func comparePKValues(valuesA, valuesB []any) int {
 			return 1
 		}
 
-		valAKind := reflect.TypeOf(valA).Kind()
-		valBKind := reflect.TypeOf(valB).Kind()
-
-		if isNumeric(valAKind) && isNumeric(valBKind) {
-			floatA, errA := toFloat64(valA)
-			floatB, errB := toFloat64(valB)
-
-			if errA == nil && errB == nil {
-				if floatA < floatB {
-					return -1
-				}
-				if floatA > floatB {
-					return 1
-				}
-				continue
+		if cmp, ok := CompareNumeric(valA, valB); ok {
+			if cmp != 0 {
+				return cmp
 			}
+			continue
 		}
 
 		switch vA := valA.(type) {
@@ -1334,27 +1385,133 @@ func comparePKValues(valuesA, valuesB []any) int {
 	return 0
 }
 
-func isNumeric(kind reflect.Kind) bool {
-	switch kind {
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
-		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
-		reflect.Float32, reflect.Float64:
-		return true
+
+// CompareNumeric compares two numeric values with full precision.
+// Returns -1 if a < b, 0 if a == b, 1 if a > b, and ok=true if both
+// values are numeric. Returns (0, false) if either value is not numeric.
+//
+// Uses an int64 fast path for integral values and falls back to
+// math/big.Float for json.Number decimals, large uint64, and floats.
+func CompareNumeric(a, b any) (int, bool) {
+	ai, aOk := asInt64(a)
+	bi, bOk := asInt64(b)
+	if aOk && bOk {
+		switch {
+		case ai < bi:
+			return -1, true
+		case ai > bi:
+			return 1, true
+		default:
+			return 0, true
+		}
+	}
+
+	af, aOk := toBigFloat(a)
+	bf, bOk := toBigFloat(b)
+	if aOk && bOk {
+		return af.Cmp(bf), true
+	}
+	return 0, false
+}
+
+// asInt64 attempts a lossless conversion to int64.
+// Returns false for floats, fractional json.Numbers, and uint64 values
+// that overflow int64.
+func asInt64(v any) (int64, bool) {
+	switch n := v.(type) {
+	case json.Number:
+		i, err := n.Int64()
+		return i, err == nil
+	case int:
+		return int64(n), true
+	case int8:
+		return int64(n), true
+	case int16:
+		return int64(n), true
+	case int32:
+		return int64(n), true
+	case int64:
+		return n, true
+	case uint:
+		if n <= math.MaxInt64 {
+			return int64(n), true
+		}
+		return 0, false
+	case uint8:
+		return int64(n), true
+	case uint16:
+		return int64(n), true
+	case uint32:
+		return int64(n), true
+	case uint64:
+		if n <= math.MaxInt64 {
+			return int64(n), true
+		}
+		return 0, false
 	default:
-		return false
+		return 0, false
 	}
 }
 
-func toFloat64(v any) (float64, error) {
-	val := reflect.ValueOf(v)
-	switch val.Kind() {
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return float64(val.Int()), nil
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		return float64(val.Uint()), nil
-	case reflect.Float32, reflect.Float64:
-		return val.Float(), nil
+// bigFloatPrec is the precision used for big.Float comparisons.
+// 256 bits handles ~77 decimal digits, covering PostgreSQL NUMERIC
+// precision for all practical cases.
+const bigFloatPrec = 256
+
+// toBigFloat converts any numeric value to a *big.Float for precise comparison.
+func toBigFloat(v any) (*big.Float, bool) {
+	switch n := v.(type) {
+	case json.Number:
+		f, _, err := big.ParseFloat(n.String(), 10, bigFloatPrec, big.ToNearestEven)
+		return f, err == nil
+	case int:
+		return new(big.Float).SetPrec(bigFloatPrec).SetInt64(int64(n)), true
+	case int8:
+		return new(big.Float).SetPrec(bigFloatPrec).SetInt64(int64(n)), true
+	case int16:
+		return new(big.Float).SetPrec(bigFloatPrec).SetInt64(int64(n)), true
+	case int32:
+		return new(big.Float).SetPrec(bigFloatPrec).SetInt64(int64(n)), true
+	case int64:
+		return new(big.Float).SetPrec(bigFloatPrec).SetInt64(n), true
+	case uint:
+		return new(big.Float).SetPrec(bigFloatPrec).SetUint64(uint64(n)), true
+	case uint8:
+		return new(big.Float).SetPrec(bigFloatPrec).SetUint64(uint64(n)), true
+	case uint16:
+		return new(big.Float).SetPrec(bigFloatPrec).SetUint64(uint64(n)), true
+	case uint32:
+		return new(big.Float).SetPrec(bigFloatPrec).SetUint64(uint64(n)), true
+	case uint64:
+		return new(big.Float).SetPrec(bigFloatPrec).SetUint64(n), true
+	case float32:
+		f64 := float64(n)
+		if math.IsNaN(f64) || math.IsInf(f64, 0) {
+			return nil, false
+		}
+		return new(big.Float).SetPrec(bigFloatPrec).SetFloat64(f64), true
+	case float64:
+		if math.IsNaN(n) || math.IsInf(n, 0) {
+			return nil, false
+		}
+		return new(big.Float).SetPrec(bigFloatPrec).SetFloat64(n), true
+	case pgtype.Numeric:
+		if n.Status == pgtype.Present {
+			if text, err := n.EncodeText(nil, nil); err == nil {
+				f, _, err := big.ParseFloat(string(text), 10, bigFloatPrec, big.ToNearestEven)
+				return f, err == nil
+			}
+		}
+		return nil, false
+	case pgxv5type.Numeric:
+		if n.Valid {
+			if text, err := n.MarshalJSON(); err == nil {
+				f, _, err := big.ParseFloat(string(text), 10, bigFloatPrec, big.ToNearestEven)
+				return f, err == nil
+			}
+		}
+		return nil, false
 	default:
-		return 0, fmt.Errorf("unsupported type for numeric conversion: %T", v)
+		return nil, false
 	}
 }

--- a/pkg/common/utils_test.go
+++ b/pkg/common/utils_test.go
@@ -2,10 +2,13 @@ package common
 
 import (
 	"encoding/base64"
+	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
 	pgxv5type "github.com/jackc/pgx/v5/pgtype"
+	"github.com/pgedge/ace/pkg/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -284,4 +287,83 @@ func TestConvertToPgxType_TimetzReturnsString(t *testing.T) {
 			require.Equal(t, input, s)
 		})
 	}
+}
+
+func TestConvertToPgxType_JsonNumberBigint(t *testing.T) {
+	// json.Number must preserve full precision for bigint values that exceed
+	// float64's 2^53 exact integer range. This is the root cause of the repair
+	// corruption bug for tables with large bigint primary keys.
+	tests := []struct {
+		name     string
+		input    json.Number
+		pgType   string
+		expected int64
+	}{
+		{"customer PK", json.Number("415588913294348289"), "bigint", 415588913294348289},
+		{"near max int64", json.Number("9223372036854775806"), "int8", 9223372036854775806},
+		{"small value", json.Number("42"), "integer", 42},
+		{"negative", json.Number("-1234567890123456789"), "bigint", -1234567890123456789},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			val, err := ConvertToPgxType(tt.input, tt.pgType)
+			require.NoError(t, err)
+			i64, ok := val.(int64)
+			require.True(t, ok, "expected int64, got %T", val)
+			require.Equal(t, tt.expected, i64)
+		})
+	}
+}
+
+func TestConvertToPgxType_JsonNumberNumeric(t *testing.T) {
+	// json.Number for numeric/decimal should preserve full precision via
+	// pgtype.Numeric (not lossy float64 conversion).
+	n := json.Number("12345678901234567.89012345")
+	val, err := ConvertToPgxType(n, "numeric")
+	require.NoError(t, err)
+	require.NotNil(t, val)
+
+	// Must NOT be float64 — that would lose precision
+	_, isFloat := val.(float64)
+	require.False(t, isFloat, "numeric json.Number must not convert to float64")
+
+	// Verify it's a *pgtype.Numeric by checking the type name
+	typeName := fmt.Sprintf("%T", val)
+	require.Contains(t, typeName, "Numeric", "expected pgtype.Numeric, got %s", typeName)
+}
+
+func TestConvertToPgxType_JsonNumberFloat(t *testing.T) {
+	n := json.Number("3.14")
+	val, err := ConvertToPgxType(n, "double precision")
+	require.NoError(t, err)
+
+	f, ok := val.(float64)
+	require.True(t, ok, "expected float64, got %T", val)
+	require.InDelta(t, 3.14, f, 1e-10)
+}
+
+func TestStringifyOrderedMapKey_JsonNumber(t *testing.T) {
+	// json.Number values from UseNumber() must stringify to the exact original
+	// string, not scientific notation.
+	row := types.OrderedMap{
+		{Key: "id", Value: json.Number("415588913294348289")},
+		{Key: "name", Value: "test"},
+	}
+
+	key, err := StringifyOrderedMapKey(row, []string{"id"})
+	require.NoError(t, err)
+	require.Equal(t, "415588913294348289", key, "PK must stringify to exact decimal, not scientific notation")
+}
+
+func TestStringifyOrderedMapKey_JsonNumberNoPKCollision(t *testing.T) {
+	// Two adjacent large bigint PKs must NOT collide after stringification.
+	row1 := types.OrderedMap{{Key: "id", Value: json.Number("415588913294348289")}}
+	row2 := types.OrderedMap{{Key: "id", Value: json.Number("415588913294348290")}}
+
+	key1, err := StringifyOrderedMapKey(row1, []string{"id"})
+	require.NoError(t, err)
+	key2, err := StringifyOrderedMapKey(row2, []string{"id"})
+	require.NoError(t, err)
+	require.NotEqual(t, key1, key2, "adjacent bigint PKs must not collide")
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -163,6 +163,7 @@ func (om *OrderedMap) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
 
 	t, err := dec.Token()
 	if err != nil {

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -1,0 +1,68 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOrderedMap_JSONRoundtrip_BigintPrecision(t *testing.T) {
+	// OrderedMap must preserve full precision for large bigint values through
+	// JSON marshal/unmarshal. Values > 2^53 lose precision when stored as
+	// float64, so UnmarshalJSON must use json.Number.
+	original := OrderedMap{
+		{Key: "id", Value: json.Number("415588913294348289")},
+		{Key: "name", Value: "test"},
+	}
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var roundtripped OrderedMap
+	err = json.Unmarshal(data, &roundtripped)
+	require.NoError(t, err)
+
+	// The id value must be a json.Number with the exact original string
+	idVal, ok := roundtripped.Get("id")
+	require.True(t, ok)
+
+	n, ok := idVal.(json.Number)
+	require.True(t, ok, "expected json.Number after roundtrip, got %T", idVal)
+	require.Equal(t, "415588913294348289", n.String())
+
+	// Verify it converts to the correct int64
+	i64, err := n.Int64()
+	require.NoError(t, err)
+	require.Equal(t, int64(415588913294348289), i64)
+}
+
+func TestOrderedMap_JSONRoundtrip_MultipleNumericTypes(t *testing.T) {
+	// JSON containing various numeric types should all survive roundtrip
+	jsonStr := `{"bigint_pk":415588913294348289,"small_int":42,"decimal":123.456,"negative":-9876543210}`
+
+	var om OrderedMap
+	err := json.Unmarshal([]byte(jsonStr), &om)
+	require.NoError(t, err)
+
+	tests := []struct {
+		key      string
+		expected string
+	}{
+		{"bigint_pk", "415588913294348289"},
+		{"small_int", "42"},
+		{"decimal", "123.456"},
+		{"negative", "-9876543210"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			val, ok := om.Get(tt.key)
+			require.True(t, ok)
+
+			n, ok := val.(json.Number)
+			require.True(t, ok, "expected json.Number for %s, got %T", tt.key, val)
+			require.Equal(t, tt.expected, n.String())
+		})
+	}
+}

--- a/tests/integration/table_repair_test.go
+++ b/tests/integration/table_repair_test.go
@@ -2168,3 +2168,166 @@ func TestTableRepair_MixedOps_PreserveOrigin(t *testing.T) {
 	log.Println("  - INSERT: 2 missing rows restored with preserved origin/timestamp")
 	log.Println("  - UPDATE: 2 modified rows corrected with preserved origin/timestamp")
 }
+
+// TestTableRepair_LargeBigintPK verifies that table repair correctly handles
+// bigint primary keys whose values exceed float64's exact integer range (2^53).
+// Before the fix, JSON deserialization converted these to float64, silently
+// truncating the PK values and causing:
+//   - PK collisions (distinct PKs mapping to the same float64)
+//   - Wrong rows being upserted/deleted
+//   - Data corruption on both the repaired and source-of-truth nodes
+//
+// The test uses PKs that are adjacent integers above 2^53, which all collapse
+// to the same float64 value without the json.Number fix.
+func TestTableRepair_LargeBigintPK(t *testing.T) {
+	ctx := context.Background()
+	tableName := "bigint_pk_repair"
+	qualifiedTableName := fmt.Sprintf("%s.%s", testSchema, tableName)
+
+	// PKs chosen to collide under float64: all map to the same float64 value.
+	// 415588913294348288 is the nearest float64-representable integer.
+	// 415588913294348289, ...290, ...291 all round to ...288 as float64.
+	collisionPKs := []int64{
+		415588913294348288,
+		415588913294348289,
+		415588913294348290,
+		415588913294348291,
+	}
+
+	createTableSQL := fmt.Sprintf(`
+CREATE SCHEMA IF NOT EXISTS "%s";
+CREATE TABLE IF NOT EXISTS %s.%s (
+    id BIGINT PRIMARY KEY,
+    data TEXT,
+    amount NUMERIC(20, 4)
+);`, testSchema, testSchema, tableName)
+
+	for i, pool := range []*pgxpool.Pool{pgCluster.Node1Pool, pgCluster.Node2Pool} {
+		nodeName := pgCluster.ClusterNodes[i]["Name"].(string)
+		_, err := pool.Exec(ctx, createTableSQL)
+		require.NoErrorf(t, err, "Failed to create table on %s", nodeName)
+		_, err = pool.Exec(ctx, fmt.Sprintf("TRUNCATE TABLE %s CASCADE", qualifiedTableName))
+		require.NoErrorf(t, err, "Failed to truncate table on %s", nodeName)
+		_, err = pool.Exec(ctx, fmt.Sprintf(`SELECT spock.repset_add_table('default', '%s');`, qualifiedTableName))
+		require.NoErrorf(t, err, "Failed to add table to repset on %s", nodeName)
+	}
+
+	t.Cleanup(func() {
+		_, _ = pgCluster.Node1Pool.Exec(ctx, fmt.Sprintf(`SELECT spock.repset_remove_table('default', '%s');`, qualifiedTableName))
+		for _, pool := range []*pgxpool.Pool{pgCluster.Node1Pool, pgCluster.Node2Pool} {
+			_, _ = pool.Exec(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s CASCADE", qualifiedTableName))
+		}
+		files, _ := filepath.Glob("*_diffs-*.json")
+		for _, f := range files {
+			_ = os.Remove(f)
+		}
+	})
+
+	insertRow := func(pool *pgxpool.Pool, id int64, data string, amount string) {
+		tx, err := pool.Begin(ctx)
+		require.NoError(t, err)
+		defer func() { _ = tx.Rollback(ctx) }()
+
+		_, err = tx.Exec(ctx, "SELECT spock.repair_mode(true)")
+		require.NoError(t, err)
+
+		_, err = tx.Exec(ctx,
+			fmt.Sprintf("INSERT INTO %s (id, data, amount) VALUES ($1, $2, $3::numeric)", qualifiedTableName),
+			id, data, amount)
+		require.NoError(t, err)
+
+		_, err = tx.Exec(ctx, "SELECT spock.repair_mode(false)")
+		require.NoError(t, err)
+		require.NoError(t, tx.Commit(ctx))
+	}
+
+	// ---- Set up divergence ----
+	// Common row on both nodes (same data)
+	insertRow(pgCluster.Node1Pool, collisionPKs[0], "common_row", "1000000.1234")
+	insertRow(pgCluster.Node2Pool, collisionPKs[0], "common_row", "1000000.1234")
+
+	// Rows only on node1 (should be deleted when node2 is source of truth)
+	insertRow(pgCluster.Node1Pool, collisionPKs[1], "n1_only_289", "2000000.5678")
+
+	// Rows only on node2 (should be inserted into node1)
+	insertRow(pgCluster.Node2Pool, collisionPKs[2], "n2_only_290", "3000000.9012")
+
+	// Modified row: same PK on both nodes, different data
+	insertRow(pgCluster.Node1Pool, collisionPKs[3], "old_data_291", "4000000.0001")
+	insertRow(pgCluster.Node2Pool, collisionPKs[3], "new_data_291", "4000000.9999")
+
+	// ---- Run diff ----
+	diffFile := runTableDiff(t, qualifiedTableName, []string{serviceN1, serviceN2})
+
+	// Verify diff found the expected number of differences:
+	// - collisionPKs[1]: node1-only → 1 diff
+	// - collisionPKs[2]: node2-only → 1 diff
+	// - collisionPKs[3]: modified   → 1 diff
+	// Total: 3 diffs
+	diffData, err := os.ReadFile(diffFile)
+	require.NoError(t, err)
+	var diffOutput struct {
+		Summary struct {
+			DiffRowsCount map[string]int `json:"diff_rows_count"`
+		} `json:"summary"`
+	}
+	require.NoError(t, json.Unmarshal(diffData, &diffOutput))
+	totalDiffs := 0
+	for _, count := range diffOutput.Summary.DiffRowsCount {
+		totalDiffs += count
+	}
+	assert.Equal(t, 3, totalDiffs, "Expected exactly 3 differences before repair")
+
+	// ---- Run repair (node2 is source of truth) ----
+	repairTask := newTestTableRepairTask(serviceN2, qualifiedTableName, diffFile)
+	err = repairTask.Run(false)
+	require.NoError(t, err, "Table repair failed")
+
+	// ---- Verify repair ----
+
+	// 1. Tables should now match (zero diffs)
+	assertNoTableDiff(t, qualifiedTableName)
+
+	// 2. Row counts should match: 3 rows (common + n2_only_290 + modified_291)
+	//    collisionPKs[1] (n1_only_289) should have been deleted from node1
+	count1 := getTableCount(t, ctx, pgCluster.Node1Pool, qualifiedTableName)
+	count2 := getTableCount(t, ctx, pgCluster.Node2Pool, qualifiedTableName)
+	assert.Equal(t, count1, count2, "Row counts should match after repair")
+	assert.Equal(t, 3, count1, "Expected 3 rows after repair")
+
+	// 3. Verify each PK has the correct data on the repaired node (node1)
+	verifyRow := func(pool *pgxpool.Pool, id int64, expectedData string, expectedAmount string) {
+		var data string
+		var amount string
+		err := pool.QueryRow(ctx,
+			fmt.Sprintf("SELECT data, amount::text FROM %s WHERE id = $1", qualifiedTableName), id).
+			Scan(&data, &amount)
+		require.NoError(t, err, "Row with PK %d should exist", id)
+		assert.Equal(t, expectedData, data, "Wrong data for PK %d", id)
+		assert.Equal(t, expectedAmount, amount, "Wrong amount for PK %d", id)
+	}
+
+	// Common row should be unchanged
+	verifyRow(pgCluster.Node1Pool, collisionPKs[0], "common_row", "1000000.1234")
+
+	// Node1-only row should have been deleted
+	var deletedCount int
+	err = pgCluster.Node1Pool.QueryRow(ctx,
+		fmt.Sprintf("SELECT count(*) FROM %s WHERE id = $1", qualifiedTableName), collisionPKs[1]).
+		Scan(&deletedCount)
+	require.NoError(t, err)
+	assert.Equal(t, 0, deletedCount, "Node1-only row (PK %d) should have been deleted", collisionPKs[1])
+
+	// Node2-only row should have been inserted into node1
+	verifyRow(pgCluster.Node1Pool, collisionPKs[2], "n2_only_290", "3000000.9012")
+
+	// Modified row should have node2's version on node1
+	verifyRow(pgCluster.Node1Pool, collisionPKs[3], "new_data_291", "4000000.9999")
+
+	log.Println("TestTableRepair_LargeBigintPK PASSED")
+	log.Println("  - 4 adjacent PKs above 2^53 that collide under float64")
+	log.Println("  - DELETE: node1-only row correctly removed")
+	log.Println("  - INSERT: node2-only row correctly added to node1")
+	log.Println("  - UPDATE: modified row correctly updated on node1")
+	log.Println("  - All PKs preserved with exact precision (no float64 truncation)")
+}


### PR DESCRIPTION
OrderedMap.UnmarshalJSON used Go's default JSON number decoding (float64), which silently truncates integers exceeding 2^53. For tables with large bigint primary keys (e.g. snowflake IDs like 415588913294348289), this caused:

- PK corruption: 415588913294348289 → 415588913294348288 (off by 1)
- PK collisions: adjacent PKs mapped to the same float64, causing rows to silently overwrite each other in repair maps
- Wrong upserts/deletes: repairs targeted wrong rows or missed them
- Growing diffs after repair: corrupted values replicated via spock

Fix: add dec.UseNumber() to OrderedMap.UnmarshalJSON so JSON numbers are preserved as json.Number strings. Update ConvertToPgxType to handle json.Number for integer types (lossless Int64 parse), numeric/decimal (exact string via pgtype.Numeric), and float types (Float64 parse). Also update comparePKValues/toFloat64 to recognize json.Number.