### PR TITLE
Add missing integration tests to CI and fix json.Number assertions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Run crash recovery origin-filter test
       run: go test -count=1 -v ./tests/integration -run 'TestTableDiffAgainstOriginWithUntil'
 
-    - name: Run crash recovery origin-filter test
+    - name: Run advanced repair plan tests
       run: go test -count=1 -v ./tests/integration -run 'TestAdvancedRepairPlan'
 
     - name: Run repset-diff tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,5 +43,17 @@ jobs:
     - name: Run crash recovery origin-filter test
       run: go test -count=1 -v ./tests/integration -run 'TestAdvancedRepairPlan'
 
-    - name: Run connection pool cap test
-      run: go test -count=1 -v ./tests/integration -run 'TestRepsetDiff_MaxConnectionsCap'
+    - name: Run repset-diff tests
+      run: go test -count=1 -v ./tests/integration -run 'TestRepsetDiff_'
+
+    - name: Run schema-diff tests
+      run: go test -count=1 -v ./tests/integration -run 'TestSchemaDiff_'
+
+    - name: Run Merkle tree numeric scale invariance test
+      run: go test -count=1 -v ./tests/integration -run 'TestMerkleTreeNumericScaleInvariance'
+
+    - name: Run catastrophic single-node failure recovery test
+      run: go test -count=1 -v ./tests/integration -run 'TestCatastrophicSingleNodeFailure'
+
+    - name: Run timestamp comparison tests
+      run: go test -count=1 -v ./tests/integration -run 'TestCompareTimestampsExact|TestPostgreSQLMicrosecondPrecision|TestOldVsNewComparison'

--- a/tests/integration/repset_diff_test.go
+++ b/tests/integration/repset_diff_test.go
@@ -177,7 +177,7 @@ func TestRepsetDiff_DivergentTable(t *testing.T) {
 		assert.Len(t, n1Rows, 1, "n1 should have 1 extra row")
 		if len(n1Rows) > 0 {
 			id, _ := n1Rows[0].Get("id")
-			assert.Equal(t, float64(99), id, "divergent row should be id=99")
+			assert.Equal(t, json.Number("99"), id, "divergent row should be id=99")
 			val, _ := n1Rows[0].Get("val")
 			assert.Equal(t, "only_on_n1", val)
 		}
@@ -298,6 +298,6 @@ func TestRepsetDiff_MultipleTables(t *testing.T) {
 		n1Rows := pair.Rows[serviceN1]
 		require.Len(t, n1Rows, 1)
 		id, _ := n1Rows[0].Get("id")
-		assert.Equal(t, float64(99), id)
+		assert.Equal(t, json.Number("99"), id)
 	}
 }


### PR DESCRIPTION
Fix TestRepsetDiff_DivergentTable and TestRepsetDiff_MultipleTables which compared float64(99) against json.Number("99") — broken since OrderedMap.UnmarshalJSON started using dec.UseNumber() for bigint precision.

Add CI steps for repset-diff, schema-diff, Merkle numeric scale invariance, catastrophic single-node failure recovery, and timestamp comparison tests that were not being run.