### PR TITLE
Scheduler: max one instance of a job at a time

### DIFF
--- a/internal/consistency/diff/repset_diff.go
+++ b/internal/consistency/diff/repset_diff.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pgedge/ace/db/queries"
 	"github.com/pgedge/ace/internal/infra/db"
 	utils "github.com/pgedge/ace/pkg/common"
+	"github.com/pgedge/ace/pkg/config"
 	"github.com/pgedge/ace/pkg/logger"
 	"github.com/pgedge/ace/pkg/taskstore"
 	"github.com/pgedge/ace/pkg/types"
@@ -88,7 +89,7 @@ func NewRepsetDiffTask() *RepsetDiffCmd {
 }
 
 func (c *RepsetDiffCmd) connOpts() auth.ConnectionOptions {
-	return auth.ConnectionOptions{}
+	return auth.ConnectionOptions{PoolSize: c.MaxConnections}
 }
 
 func (c *RepsetDiffCmd) parseSkipList() error {
@@ -230,6 +231,10 @@ func (c *RepsetDiffCmd) Validate() error {
 	}
 	if c.RepsetName == "" {
 		return fmt.Errorf("repset name is required")
+	}
+	cfg := config.Get()
+	if c.MaxConnections == 0 && cfg != nil {
+		c.MaxConnections = cfg.TableDiff.MaxConnections
 	}
 	if c.MaxConnections < 0 {
 		return fmt.Errorf("max_connections must be >= 1 (or 0 to derive from concurrency factor)")

--- a/internal/consistency/diff/schema_diff.go
+++ b/internal/consistency/diff/schema_diff.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pgedge/ace/db/queries"
 	"github.com/pgedge/ace/internal/infra/db"
 	utils "github.com/pgedge/ace/pkg/common"
+	"github.com/pgedge/ace/pkg/config"
 	"github.com/pgedge/ace/pkg/logger"
 	"github.com/pgedge/ace/pkg/taskstore"
 	"github.com/pgedge/ace/pkg/types"
@@ -178,6 +179,10 @@ func (c *SchemaDiffCmd) Validate() error {
 		return fmt.Errorf("schema-diff needs at least two nodes to compare")
 	}
 
+	cfg := config.Get()
+	if c.MaxConnections == 0 && cfg != nil {
+		c.MaxConnections = cfg.TableDiff.MaxConnections
+	}
 	if c.MaxConnections < 0 {
 		return fmt.Errorf("max_connections must be >= 1 (or 0 to derive from concurrency factor)")
 	}
@@ -220,7 +225,7 @@ func (c *SchemaDiffCmd) RunChecks(skipValidation bool) error {
 			}
 		}
 
-		pool, err := auth.GetClusterNodeConnection(c.Ctx, nodeWithDBInfo, auth.ConnectionOptions{})
+		pool, err := auth.GetClusterNodeConnection(c.Ctx, nodeWithDBInfo, auth.ConnectionOptions{PoolSize: c.MaxConnections})
 		if err != nil {
 			return fmt.Errorf("could not connect to node %s: %w", nodeName, err)
 		}
@@ -300,7 +305,7 @@ func (task *SchemaDiffCmd) schemaObjectDiff() error {
 			}
 		}
 
-		pool, err := auth.GetClusterNodeConnection(task.Ctx, nodeWithDBInfo, auth.ConnectionOptions{})
+		pool, err := auth.GetClusterNodeConnection(task.Ctx, nodeWithDBInfo, auth.ConnectionOptions{PoolSize: task.MaxConnections})
 		if err != nil {
 			logger.Warn("could not connect to node %s: %v. Skipping.", nodeName, err)
 			continue

--- a/internal/jobs/scheduler.go
+++ b/internal/jobs/scheduler.go
@@ -69,9 +69,17 @@ func (m *Manager) Run(ctx context.Context) error {
 
 		switch {
 		case job.Cron != "":
-			gJob, err = m.scheduler.NewJob(gocron.CronJob(job.Cron, false), gocron.NewTask(runFn))
+			gJob, err = m.scheduler.NewJob(
+				gocron.CronJob(job.Cron, false),
+				gocron.NewTask(runFn),
+				gocron.WithSingletonMode(gocron.LimitModeReschedule),
+			)
 		case job.Frequency > 0:
-			gJob, err = m.scheduler.NewJob(gocron.DurationJob(job.Frequency), gocron.NewTask(runFn))
+			gJob, err = m.scheduler.NewJob(
+				gocron.DurationJob(job.Frequency),
+				gocron.NewTask(runFn),
+				gocron.WithSingletonMode(gocron.LimitModeReschedule),
+			)
 		default:
 			return fmt.Errorf("scheduler: job %q requires either frequency or cron", job.Name)
 		}


### PR DESCRIPTION
Currently the scheduler will spawn a new job even if the previous one of the same type has not finished. That can happen for small values of `run_frequency`.

Instead, skip starting the new job if the previous one is still running.

Also, use `max_connections` for repset-diff and schema-diff discovery to align with the table-diff pools, even though in practice they only open a connection or two and then close them.

ACE-182