### PR TITLE
Fix/go version docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The Active Consistency Engine (ACE) is a tool designed to ensure eventual consis
 
 ## Building ACE
 
-Before building ACE, you need to install Go (version 1.18 or higher).
+Before building ACE, you need to install Go (version 1.26 or higher).
 
 1.  Clone the repository:
     ```sh

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,6 +36,7 @@ The [`ace.yaml` file](https://github.com/pgEdge/ace/blob/main/ace.yaml) defines 
 | mtree → cdc --> slot_name | Logical decoding slot name for mtree CDC. **Default: "ace_mtree_slot"** |
 | mtree → cdc --> publication_name | Publication used for mtree CDC. **Default: "ace_mtree_pub"** |
 | mtree → cdc --> cdc_processing_timeout | CDC processing timeout (s). **Default: 30** |
+| mtree → cdc --> cdc_metadata_flush_seconds | How often (s) CDC metadata is flushed to disk. **Default: 10** |
 | mtree --> schema | Schema used for mtree metadata/objects. **Default: "spock"** |
 | mtree → diff --> min_block_size | Minimum Merkle diff block size. **Default: 1000** |
 | mtree → diff --> block_size | Target Merkle diff block size. **Default: 100000** |
@@ -45,8 +46,8 @@ The [`ace.yaml` file](https://github.com/pgEdge/ace/blob/main/ace.yaml) defines 
 | (root) --> schedule_jobs | Array of job definitions consumed by the scheduler (see [Scheduling ACE Runs](scheduling.md)). **Default: []** |
 | (root) --> schedule_config | Array of cadence settings (`run_frequency` or `crontab_schedule`) that reference entries in `schedule_jobs`. **Default: []** |
 | cert_auth --> use_cert_auth | Use client certificate authentication. **Default: true** |
-| cert_auth --> user_cert_file | Path to user/client certificate. **Default: "data/pg16/pki/admin-cert/admin.crt"** |
-| cert_auth --> user_key_file | Path to user/client private key. **Default: "data/pg16/pki/admin-cert/admin.key"** |
+| cert_auth --> ace_user_cert_file | Path to user/client certificate. **Default: "data/pg16/pki/admin-cert/admin.crt"** |
+| cert_auth --> ace_user_key_file | Path to user/client private key. **Default: "data/pg16/pki/admin-cert/admin.key"** |
 | cert_auth --> ca_cert_file | Path to CA certificate. **Default: "data/pg16/pki/ca.crt"** |
 | (root) --> debug_mode | Enable verbose/diagnostic logging. **Default: false** |
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -14,8 +14,8 @@ Requires Go 1.26+. No CGO or system SQLite libraries needed — the project uses
 # Latest release
 go install github.com/pgedge/ace/cmd/ace@latest
 
-# Specific version
-go install github.com/pgedge/ace/cmd/ace@v1.5.3
+# Specific version — update to the latest tag from GitHub Releases
+go install github.com/pgedge/ace/cmd/ace@v1.9.0
 ```
 
 The binary lands in `GOBIN` if set, otherwise `$GOPATH/bin` (defaults to `~/go/bin`). Add that to your `PATH`:
@@ -29,7 +29,7 @@ export PATH="$(go env GOBIN || go env GOPATH)/bin:$PATH"
 Grab the prebuilt archive for your platform from GitHub Releases and unpack the `ace` binary:
 
 ```sh
-ACE_VER=v1.5.3
+ACE_VER=v1.9.0  # update to the latest tag from GitHub Releases
 OS=Linux    # or Darwin or Windows
 ARCH=x86_64 # or arm64
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -8,7 +8,7 @@ Choose the option that fits your environment:
 
 ## Install via Go
 
-Requires Go 1.20+ with CGO enabled (SQLite). Make sure build deps are present (`libsqlite3-dev`/`sqlite-devel` on Linux).
+Requires Go 1.26+. No CGO or system SQLite libraries needed — the project uses a pure-Go SQLite driver.
 
 ```sh
 # Latest release


### PR DESCRIPTION
- sync Go version requirement to 1.26, drop stale CGO note
- fix config key names, add missing CDC key, update install version