### PR TITLE
fix: mtree table-diff drops rows in the open-ended tail leaf

### DIFF
--- a/internal/consistency/mtree/merkle.go
+++ b/internal/consistency/mtree/merkle.go
@@ -2192,26 +2192,24 @@ func (m *MerkleTreeTask) getPkeyBatches(pool1, pool2 *pgxpool.Pool, mismatchedPo
 
 	allRanges := append(leafRanges1, leafRanges2...)
 
-	// A leaf with range_end IS NULL extends to +infinity, and range_start IS
-	// NULL extends to -infinity. GeneratePkeyOffsetsQuery always produces a
-	// last leaf with range_end = NULL — the LEAD() over the trailing seq=2
-	// row yields NULL — so the open-ended tail is the common case, not a
-	// corner one. Track which sides need an extra unbounded slice; without
-	// it the finite-boundary slicing below never queries past the last
-	// boundary, and rows on the non-reference node beyond the reference's
-	// last_row are silently dropped from the diff.
+	// GeneratePkeyOffsetsQuery always emits a last leaf with range_end =
+	// NULL, so the boundary set must track open sides explicitly —
+	// otherwise rows past the reference's last_row are never queried.
+	// GetLeafRanges returns NULL bounds as []any{nil} (simple PK) or
+	// []any{nil, nil, ...} (composite PK), not as a Go nil slice — use
+	// allNil to normalise.
 	boundaries := []any{}
 	hasOpenStart, hasOpenEnd := false, false
 	for _, r := range allRanges {
-		if r.RangeStart != nil {
-			boundaries = append(boundaries, r.RangeStart)
-		} else {
+		if allNil(r.RangeStart) {
 			hasOpenStart = true
-		}
-		if r.RangeEnd != nil {
-			boundaries = append(boundaries, r.RangeEnd)
 		} else {
+			boundaries = append(boundaries, r.RangeStart)
+		}
+		if allNil(r.RangeEnd) {
 			hasOpenEnd = true
+		} else {
+			boundaries = append(boundaries, r.RangeEnd)
 		}
 	}
 
@@ -2233,14 +2231,16 @@ func (m *MerkleTreeTask) getPkeyBatches(pool1, pool2 *pgxpool.Pool, mismatchedPo
 	var slices [][2]any
 	switch len(sortedBoundaries) {
 	case 0:
-		// Every mismatched leaf is fully unbounded (start and end NULL).
-		// One fully-open slice makes processWorkItem scan both sides.
 		if hasOpenStart || hasOpenEnd {
 			slices = append(slices, [2]any{nil, nil})
 		}
 	case 1:
-		s := sortedBoundaries[0]
-		slices = append(slices, [2]any{s, s})
+		// Skip the single-point slice when an open-side slice below
+		// already subsumes it.
+		if !hasOpenStart && !hasOpenEnd {
+			s := sortedBoundaries[0]
+			slices = append(slices, [2]any{s, s})
+		}
 	default:
 		for i := 0; i < len(sortedBoundaries)-1; i++ {
 			s := sortedBoundaries[i]
@@ -2251,11 +2251,6 @@ func (m *MerkleTreeTask) getPkeyBatches(pool1, pool2 *pgxpool.Pool, mismatchedPo
 		}
 	}
 
-	// Cover the unbounded regions outside the finite boundary set when any
-	// mismatched leaf is open on that side. boundaryToSlice(nil) returns
-	// nil; processWorkItem then omits the corresponding inequality clause,
-	// producing WHERE pkey >= firstBoundary (open-end) or WHERE pkey <=
-	// firstBoundary (open-start), so the diff sees rows past the envelope.
 	if len(sortedBoundaries) > 0 {
 		if hasOpenStart {
 			slices = append(slices, [2]any{nil, sortedBoundaries[0]})

--- a/internal/consistency/mtree/merkle.go
+++ b/internal/consistency/mtree/merkle.go
@@ -2192,13 +2192,26 @@ func (m *MerkleTreeTask) getPkeyBatches(pool1, pool2 *pgxpool.Pool, mismatchedPo
 
 	allRanges := append(leafRanges1, leafRanges2...)
 
+	// A leaf with range_end IS NULL extends to +infinity, and range_start IS
+	// NULL extends to -infinity. GeneratePkeyOffsetsQuery always produces a
+	// last leaf with range_end = NULL — the LEAD() over the trailing seq=2
+	// row yields NULL — so the open-ended tail is the common case, not a
+	// corner one. Track which sides need an extra unbounded slice; without
+	// it the finite-boundary slicing below never queries past the last
+	// boundary, and rows on the non-reference node beyond the reference's
+	// last_row are silently dropped from the diff.
 	boundaries := []any{}
+	hasOpenStart, hasOpenEnd := false, false
 	for _, r := range allRanges {
 		if r.RangeStart != nil {
 			boundaries = append(boundaries, r.RangeStart)
+		} else {
+			hasOpenStart = true
 		}
 		if r.RangeEnd != nil {
 			boundaries = append(boundaries, r.RangeEnd)
+		} else {
+			hasOpenEnd = true
 		}
 	}
 
@@ -2217,15 +2230,18 @@ func (m *MerkleTreeTask) getPkeyBatches(pool1, pool2 *pgxpool.Pool, mismatchedPo
 		return m.compareBoundaries(sortedBoundaries[i], sortedBoundaries[j]) < 0
 	})
 
-	if len(sortedBoundaries) == 0 {
-		return [][2][]any{}, nil
-	}
-
 	var slices [][2]any
-	if len(sortedBoundaries) == 1 {
+	switch len(sortedBoundaries) {
+	case 0:
+		// Every mismatched leaf is fully unbounded (start and end NULL).
+		// One fully-open slice makes processWorkItem scan both sides.
+		if hasOpenStart || hasOpenEnd {
+			slices = append(slices, [2]any{nil, nil})
+		}
+	case 1:
 		s := sortedBoundaries[0]
 		slices = append(slices, [2]any{s, s})
-	} else {
+	default:
 		for i := 0; i < len(sortedBoundaries)-1; i++ {
 			s := sortedBoundaries[i]
 			e := sortedBoundaries[i+1]
@@ -2233,6 +2249,24 @@ func (m *MerkleTreeTask) getPkeyBatches(pool1, pool2 *pgxpool.Pool, mismatchedPo
 				slices = append(slices, [2]any{s, e})
 			}
 		}
+	}
+
+	// Cover the unbounded regions outside the finite boundary set when any
+	// mismatched leaf is open on that side. boundaryToSlice(nil) returns
+	// nil; processWorkItem then omits the corresponding inequality clause,
+	// producing WHERE pkey >= firstBoundary (open-end) or WHERE pkey <=
+	// firstBoundary (open-start), so the diff sees rows past the envelope.
+	if len(sortedBoundaries) > 0 {
+		if hasOpenStart {
+			slices = append(slices, [2]any{nil, sortedBoundaries[0]})
+		}
+		if hasOpenEnd {
+			slices = append(slices, [2]any{sortedBoundaries[len(sortedBoundaries)-1], nil})
+		}
+	}
+
+	if len(slices) == 0 {
+		return [][2][]any{}, nil
 	}
 
 	var batches [][2][]any

--- a/tests/integration/merkle_tree_test.go
+++ b/tests/integration/merkle_tree_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -1869,4 +1870,188 @@ func TestUpdateMtreeReflectsUpdates(t *testing.T) {
 	nodesAfter := mtreeNodeHashes(t, ctx, mtreeTable)
 	require.GreaterOrEqual(t, countChangedNodes(nodesBefore, nodesAfter), 2,
 		"expected change to propagate to root AND at least one ancestor node")
+}
+
+// TestMerkleTreeBidirectionalDiff is a multi-scenario reproducer for the
+// asymmetric-diff bug: mtree table-diff reports rows present on n1 but
+// missing on n2 while silently dropping rows present on n2 but missing on n1
+// (and vice-versa once the reference role flips).
+//
+// Each scenario varies where the divergence sits relative to the reference
+// node's pkey envelope. The reference node — the one with the most rows; on a
+// tie BuildMtree's strict `count > maxRows` lets n1 win — defines the block
+// ranges via GeneratePkeyOffsetsQuery, whose final range always has
+// range_end IS NULL. getPkeyBatches collects only non-NULL boundaries when
+// slicing, so the open-ended tail contributes no slice and any row on the
+// non-reference node beyond the reference's last_row is never queried by
+// processWorkItem.
+//
+// The scenarios are designed to falsify, not just fail:
+//
+//   - ExactReproducer mirrors the bug report verbatim (n1=[1], n2=[2]).
+//   - N2HasRowsAboveN1Max keeps n1 as reference with extras stacked above
+//     its max; the open-ended-tail theory predicts n2's extras vanish.
+//   - N1HasRowAboveN2Max flips the asymmetry so n2 becomes the reference;
+//     the same bug should surface from that side — if it doesn't, the
+//     diagnosis is incomplete.
+func TestMerkleTreeBidirectionalDiff(t *testing.T) {
+	cases := []struct {
+		name         string
+		seedN1       []int
+		seedN2       []int
+		expectN1Only []int
+		expectN2Only []int
+	}{
+		{
+			name:         "ExactReproducer",
+			seedN1:       []int{1},
+			seedN2:       []int{2},
+			expectN1Only: []int{1},
+			expectN2Only: []int{2},
+		},
+		{
+			name:         "N2HasRowsAboveN1Max",
+			seedN1:       []int{1, 2, 3, 4, 5},
+			seedN2:       []int{1, 1000, 2000, 3000, 4000},
+			expectN1Only: []int{2, 3, 4, 5},
+			expectN2Only: []int{1000, 2000, 3000, 4000},
+		},
+		{
+			name:         "N1HasRowAboveN2Max",
+			seedN1:       []int{1, 10000},
+			seedN2:       []int{1, 2, 3, 4, 5, 6},
+			expectN1Only: []int{10000},
+			expectN2Only: []int{2, 3, 4, 5, 6},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			env := newSpockEnv()
+			tableName := "mtree_bidir_" + strings.ToLower(tc.name)
+			qualifiedTable := fmt.Sprintf("%s.%s", testSchema, tableName)
+			safeTable := pgx.Identifier{testSchema, tableName}.Sanitize()
+
+			// Use IF NOT EXISTS because Spock DDL replication may
+			// propagate the first node's CREATE to the second; the second
+			// explicit CREATE would otherwise fail with relation exists.
+			//
+			// Deliberately do NOT add the table to a Spock replication set:
+			// with the table outside any repset, Spock has no rule to
+			// replicate INSERTs even though the rows go to WAL, so each
+			// node holds exactly what we seed and the reproducer can
+			// actually diverge. spock.repair_mode alone does not suffice
+			// here — it suppresses apply for tables that are already
+			// replicating, not for tables freshly added to the repset.
+			for _, pool := range env.pools() {
+				_, err := pool.Exec(ctx,
+					"CREATE TABLE IF NOT EXISTS "+safeTable+" (id INT PRIMARY KEY, payload TEXT)") // nosemgrep
+				require.NoError(t, err, "create %s", qualifiedTable)
+			}
+			t.Cleanup(func() {
+				for _, pool := range env.pools() {
+					_, _ = pool.Exec(ctx, "DROP TABLE IF EXISTS "+safeTable+" CASCADE") // nosemgrep
+				}
+				files, _ := filepath.Glob("*_diffs-*.json")
+				for _, f := range files {
+					os.Remove(f)
+				}
+			})
+
+			// TRUNCATE inside repair_mode in case a DDL-replicated CREATE
+			// from a sibling subtest left rows behind on either node.
+			for _, pool := range env.pools() {
+				env.withRepairMode(t, ctx, pool, func(conn *pgxpool.Conn) {
+					_, err := conn.Exec(ctx, "TRUNCATE TABLE "+safeTable) // nosemgrep
+					require.NoError(t, err, "truncate %s", qualifiedTable)
+				})
+			}
+
+			seed := func(pool *pgxpool.Pool, ids []int) {
+				for _, id := range ids {
+					_, err := pool.Exec(ctx,
+						"INSERT INTO "+safeTable+" (id, payload) VALUES ($1, $2)", // nosemgrep
+						id, fmt.Sprintf("row-%d", id))
+					require.NoError(t, err, "seed id=%d", id)
+				}
+			}
+			seed(env.N1Pool, tc.seedN1)
+			seed(env.N2Pool, tc.seedN2)
+
+			// ANALYZE so GetRowCountEstimate reflects the seeded counts;
+			// otherwise BuildMtree falls back to pg_class.reltuples == 0
+			// and the reference-node tiebreak becomes order-dependent
+			// rather than count-driven.
+			for _, pool := range env.pools() {
+				_, err := pool.Exec(ctx, "ANALYZE "+safeTable) // nosemgrep
+				require.NoError(t, err)
+			}
+
+			// Diagnostic: dump actual rows per node so a future Spock-
+			// replication regression doesn't masquerade as an mtree bug.
+			for nodeName, pool := range map[string]*pgxpool.Pool{
+				env.ServiceN1: env.N1Pool, env.ServiceN2: env.N2Pool,
+			} {
+				rows, err := pool.Query(ctx, "SELECT id FROM "+safeTable+" ORDER BY id") // nosemgrep
+				require.NoError(t, err)
+				var got []int
+				for rows.Next() {
+					var id int
+					require.NoError(t, rows.Scan(&id))
+					got = append(got, id)
+				}
+				rows.Close()
+				t.Logf("post-seed state on %s: ids=%v", nodeName, got)
+			}
+
+			mtreeTask := env.newMerkleTreeTask(t, qualifiedTable,
+				[]string{env.ServiceN1, env.ServiceN2})
+			require.NoError(t, mtreeTask.RunChecks(false))
+			require.NoError(t, mtreeTask.MtreeInit())
+			t.Cleanup(func() {
+				if err := mtreeTask.MtreeTeardown(); err != nil {
+					t.Logf("MtreeTeardown cleanup: %v", err)
+				}
+			})
+			require.NoError(t, mtreeTask.BuildMtree())
+			require.NoError(t, mtreeTask.DiffMtree())
+
+			pair := env.pairKey()
+			nodeDiffs, ok := mtreeTask.DiffResult.NodeDiffs[pair]
+			require.True(t, ok, "diff missing pair %s; full result: %+v",
+				pair, mtreeTask.DiffResult)
+
+			gotN1 := extractDiffIDs(nodeDiffs.Rows[env.ServiceN1])
+			gotN2 := extractDiffIDs(nodeDiffs.Rows[env.ServiceN2])
+
+			sort.Ints(tc.expectN1Only)
+			sort.Ints(tc.expectN2Only)
+
+			require.Equal(t, tc.expectN1Only, gotN1,
+				"rows present only on n1 — diff under-reports n1 side")
+			require.Equal(t, tc.expectN2Only, gotN2,
+				"rows present only on n2 — open-ended-tail bug if empty")
+		})
+	}
+}
+
+func extractDiffIDs(rows []types.OrderedMap) []int {
+	ids := make([]int, 0, len(rows))
+	for _, row := range rows {
+		v, ok := row.Get("id")
+		if !ok {
+			continue
+		}
+		switch x := v.(type) {
+		case int32:
+			ids = append(ids, int(x))
+		case int64:
+			ids = append(ids, int(x))
+		case int:
+			ids = append(ids, x)
+		}
+	}
+	sort.Ints(ids)
+	return ids
 }


### PR DESCRIPTION
## Summary

`ace mtree table-diff` silently dropped any row on the non-reference node whose pkey sat past the reference's `last_row`. `GeneratePkeyOffsetsQuery` emits a final leaf with `range_end = NULL`, and `getPkeyBatches` ignored NULL bounds when building work-item slices — the open-ended tail produced no query. With `n1=[id=1], n2=[id=2]` (the bug report) the diff returned `n1=[{id:1}], n2=[]`; `table-repair` then deleted n1's row instead of converging.

## Fix

`getPkeyBatches` now tracks `hasOpenStart` / `hasOpenEnd` and appends `{nil, firstBoundary}` or `{lastBoundary, nil}` on the open side(s); the fully-unbounded edge case emits `{nil, nil}`. `processWorkItem` already treats a nil bound as "no clause for this side", so no caller changes. The single-point `{b, b}` slice is skipped when an open-side slice would subsume it.