### PR TITLE
fix: repair spock-diff against spock-enabled clusters

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,12 @@ jobs:
     - name: Run schema-diff tests
       run: go test -count=1 -v ./tests/integration -run 'TestSchemaDiff_'
 
+    - name: Run spock-diff comparison unit tests
+      run: go test -count=1 -v ./internal/consistency/diff -run 'TestCompareSubscriptions'
+
+    - name: Run spock-diff tests
+      run: go test -count=1 -v ./tests/integration -run 'TestSpockDiff_|TestGetSpockNodeAndSubInfo'
+
     - name: Run Merkle tree numeric scale invariance test
       run: go test -count=1 -v ./tests/integration -run 'TestMerkleTreeNumericScaleInvariance'
 

--- a/db/queries/queries.go
+++ b/db/queries/queries.go
@@ -868,6 +868,7 @@ func GetSpockNodeAndSubInfo(ctx context.Context, db DBQuerier) ([]types.SpockNod
 			&info.SubName,
 			&info.SubEnabled,
 			&info.SubReplicationSets,
+			&info.SubOriginName,
 		); err != nil {
 			return nil, err
 		}

--- a/db/queries/templates.go
+++ b/db/queries/templates.go
@@ -601,17 +601,19 @@ var SQLTemplates = Templates{
 	`)),
 	SpockNodeAndSubInfo: template.Must(template.New("spockNodeAndSubInfo").Parse(`
 		SELECT
-			n.node_id,
+			n.node_id::bigint,
 			n.node_name,
 			n.location,
 			n.country,
-			s.sub_id,
+			s.sub_id::bigint,
 			s.sub_name,
 			s.sub_enabled,
-			s.sub_replication_sets
+			s.sub_replication_sets,
+			COALESCE(o.node_name, '') AS sub_origin_name
 		FROM
 			spock.node n
 			LEFT OUTER JOIN spock.subscription s ON s.sub_target = n.node_id
+			LEFT OUTER JOIN spock.node o ON o.node_id = s.sub_origin
 		WHERE
 			s.sub_name IS NOT NULL;
 	`)),
@@ -626,6 +628,8 @@ var SQLTemplates = Templates{
 				relname
 			FROM
 				spock.tables
+			WHERE
+				set_name IS NOT NULL
 			ORDER BY
 				set_name, nspname, relname
 		) subquery

--- a/internal/consistency/diff/spock_diff.go
+++ b/internal/consistency/diff/spock_diff.go
@@ -531,11 +531,15 @@ func compareSubscriptions(c1, c2 SpockNodeConfig) types.SubscriptionDiff {
 	}
 
 	if n1SubsFromN2 && n2SubsFromN1 {
-		sort.Strings(s1.ReplicationSets)
-		sort.Strings(s2.ReplicationSets)
+		// Compare order-insensitively without mutating the originals: these slices
+		// are shared with the SpockConfigs JSON output, which keeps DB order.
+		sets1 := append([]string(nil), s1.ReplicationSets...)
+		sets2 := append([]string(nil), s2.ReplicationSets...)
+		sort.Strings(sets1)
+		sort.Strings(sets2)
 
 		// Both directions exist; their properties should match (names aside).
-		if s1.SubEnabled != s2.SubEnabled || !reflect.DeepEqual(s1.ReplicationSets, s2.ReplicationSets) {
+		if s1.SubEnabled != s2.SubEnabled || !reflect.DeepEqual(sets1, sets2) {
 			diff.Different = append(diff.Different, types.SubscriptionPair{
 				Name:  fmt.Sprintf("reciprocal subscriptions between %s and %s", n1Name, n2Name),
 				Node1: s1, // subscription on n1 (from n2)

--- a/internal/consistency/diff/spock_diff.go
+++ b/internal/consistency/diff/spock_diff.go
@@ -344,8 +344,15 @@ func (t *SpockDiffTask) ExecuteTask() (err error) {
 				sub := types.SpockSubscription{}
 				if ni.SubName != "" {
 					sub.SubName = ni.SubName
+					sub.ProviderNode = ni.SubOriginName
 					sub.SubEnabled = ni.SubEnabled
 					sub.ReplicationSets = ni.SubReplicationSets
+					if ni.SubOriginName == "" {
+						hint := fmt.Sprintf("Subscription '%s' has an unresolved origin node and is excluded from comparison.", sub.SubName)
+						if !utils.Contains(config.Hints, hint) {
+							config.Hints = append(config.Hints, hint)
+						}
+					}
 					if len(ni.SubReplicationSets) == 0 {
 						hint := fmt.Sprintf("Subscription '%s' has no replication sets.", sub.SubName)
 						if !utils.Contains(config.Hints, hint) {
@@ -508,48 +515,47 @@ func compareSubscriptions(c1, c2 SpockNodeConfig) types.SubscriptionDiff {
 	n1Name := c1.NodeName
 	n2Name := c2.NodeName
 
-	subsOnN1 := make(map[string]types.SpockSubscription)
-	for _, s := range c1.Subscriptions {
-		if s.SubName != "" {
-			subsOnN1[s.SubName] = s
-		}
-	}
-	subsOnN2 := make(map[string]types.SpockSubscription)
-	for _, s := range c2.Subscriptions {
-		if s.SubName != "" {
-			subsOnN2[s.SubName] = s
-		}
-	}
+	// A healthy pair requires n1 to subscribe from n2 and n2 from n1. Match on the
+	// provider node identity, not the subscription name (which users may override).
+	subsFromOnN1 := subscriptionsByProvider(c1.Subscriptions)
+	subsFromOnN2 := subscriptionsByProvider(c2.Subscriptions)
 
-	// Check for reciprocal subscriptions between n1 and n2
-	subN1toN2_name := fmt.Sprintf("sub_%s%s", n1Name, n2Name) // Subscription on n2, from n1
-	subN2toN1_name := fmt.Sprintf("sub_%s%s", n2Name, n1Name) // Subscription on n1, from n2
+	s1, n1SubsFromN2 := subsFromOnN1[n2Name] // subscription on n1 receiving from n2
+	s2, n2SubsFromN1 := subsFromOnN2[n1Name] // subscription on n2 receiving from n1
 
-	s1, s1_exists := subsOnN2[subN1toN2_name]
-	s2, s2_exists := subsOnN1[subN2toN1_name]
-
-	if !s1_exists {
-		diff.MissingOnNode2 = append(diff.MissingOnNode2, subN1toN2_name)
+	if !n1SubsFromN2 {
+		diff.MissingOnNode1 = append(diff.MissingOnNode1, n2Name)
 	}
-	if !s2_exists {
-		diff.MissingOnNode1 = append(diff.MissingOnNode1, subN2toN1_name)
+	if !n2SubsFromN1 {
+		diff.MissingOnNode2 = append(diff.MissingOnNode2, n1Name)
 	}
 
-	if s1_exists && s2_exists {
+	if n1SubsFromN2 && n2SubsFromN1 {
 		sort.Strings(s1.ReplicationSets)
 		sort.Strings(s2.ReplicationSets)
 
-		// Compare properties, ignoring the name which is expected to be different.
+		// Both directions exist; their properties should match (names aside).
 		if s1.SubEnabled != s2.SubEnabled || !reflect.DeepEqual(s1.ReplicationSets, s2.ReplicationSets) {
 			diff.Different = append(diff.Different, types.SubscriptionPair{
-				Name:  fmt.Sprintf("reciprocal subscriptions for %s and %s", n1Name, n2Name),
-				Node1: s2, // This is sub on n1
-				Node2: s1, // This is sub on n2
+				Name:  fmt.Sprintf("reciprocal subscriptions between %s and %s", n1Name, n2Name),
+				Node1: s1, // subscription on n1 (from n2)
+				Node2: s2, // subscription on n2 (from n1)
 			})
 		}
 	}
 
 	return diff
+}
+
+// subscriptionsByProvider indexes subscriptions by the node they replicate from.
+func subscriptionsByProvider(subs []types.SpockSubscription) map[string]types.SpockSubscription {
+	byProvider := make(map[string]types.SpockSubscription, len(subs))
+	for _, s := range subs {
+		if s.ProviderNode != "" {
+			byProvider[s.ProviderNode] = s
+		}
+	}
+	return byProvider
 }
 
 func compareReplicationSets(c1, c2 SpockNodeConfig) types.ReplicationSetDiff {
@@ -605,17 +611,17 @@ func compareReplicationSets(c1, c2 SpockNodeConfig) types.ReplicationSetDiff {
 
 func printDiffDetails(details types.SpockDiffDetail, node1, node2 string) {
 	if len(details.Subscriptions.MissingOnNode1) > 0 {
-		fmt.Printf("    Missing reciprocal subscriptions on %s: %v\n", node1, details.Subscriptions.MissingOnNode1)
+		fmt.Printf("    %s is missing a subscription receiving from: %v\n", node1, details.Subscriptions.MissingOnNode1)
 	}
 	if len(details.Subscriptions.MissingOnNode2) > 0 {
-		fmt.Printf("    Missing reciprocal subscriptions on %s: %v\n", node2, details.Subscriptions.MissingOnNode2)
+		fmt.Printf("    %s is missing a subscription receiving from: %v\n", node2, details.Subscriptions.MissingOnNode2)
 	}
 	if len(details.Subscriptions.Different) > 0 {
-		fmt.Println("    Subscriptions with different properties:")
+		fmt.Println("    Reciprocal subscriptions with different properties:")
 		for _, d := range details.Subscriptions.Different {
-			fmt.Printf("      - Mismatch in settings for subscriptions between %s and %s:\n", node1, node2)
-			fmt.Printf("        - On %s (subscription '%s'): Enabled: %t, Repsets: %v\n", node1, d.Node1.SubName, d.Node1.SubEnabled, d.Node1.ReplicationSets)
-			fmt.Printf("        - On %s (subscription '%s'): Enabled: %t, Repsets: %v\n", node2, d.Node2.SubName, d.Node2.SubEnabled, d.Node2.ReplicationSets)
+			fmt.Printf("      - Mismatch in settings for reciprocal subscriptions between %s and %s:\n", node1, node2)
+			fmt.Printf("        - On %s (subscription '%s', from %s): Enabled: %t, Repsets: %v\n", node1, d.Node1.SubName, d.Node1.ProviderNode, d.Node1.SubEnabled, d.Node1.ReplicationSets)
+			fmt.Printf("        - On %s (subscription '%s', from %s): Enabled: %t, Repsets: %v\n", node2, d.Node2.SubName, d.Node2.ProviderNode, d.Node2.SubEnabled, d.Node2.ReplicationSets)
 		}
 	}
 

--- a/internal/consistency/diff/spock_diff.go
+++ b/internal/consistency/diff/spock_diff.go
@@ -348,7 +348,7 @@ func (t *SpockDiffTask) ExecuteTask() (err error) {
 					sub.SubEnabled = ni.SubEnabled
 					sub.ReplicationSets = ni.SubReplicationSets
 					if ni.SubOriginName == "" {
-						hint := fmt.Sprintf("Subscription '%s' has an unresolved origin node and is excluded from comparison.", sub.SubName)
+						hint := fmt.Sprintf("Subscription '%s' has an unresolved origin node; its reciprocal peer cannot be determined and it may be reported below as a missing subscription.", sub.SubName)
 						if !utils.Contains(config.Hints, hint) {
 							config.Hints = append(config.Hints, hint)
 						}

--- a/internal/consistency/diff/spock_diff_test.go
+++ b/internal/consistency/diff/spock_diff_test.go
@@ -76,6 +76,27 @@ func TestCompareSubscriptions_DifferentReplicationSets(t *testing.T) {
 	assert.Len(t, d.Different, 1, "replication set difference should be reported")
 }
 
+// compareSubscriptions must not reorder the caller's ReplicationSets: the slices
+// are shared with the SpockConfigs section of the written JSON, which should
+// preserve database-returned order.
+func TestCompareSubscriptions_DoesNotMutateReplicationSets(t *testing.T) {
+	n1Sets := []string{"default_insert_only", "default"}
+	n2Sets := []string{"default", "default_insert_only"}
+	n1 := spockCfg("n1", types.SpockSubscription{
+		SubName: "a", ProviderNode: "n2", SubEnabled: true, ReplicationSets: n1Sets,
+	})
+	n2 := spockCfg("n2", types.SpockSubscription{
+		SubName: "b", ProviderNode: "n1", SubEnabled: true, ReplicationSets: n2Sets,
+	})
+
+	compareSubscriptions(n1, n2)
+
+	assert.Equal(t, []string{"default_insert_only", "default"}, n1Sets,
+		"n1 replication set order must be preserved")
+	assert.Equal(t, []string{"default", "default_insert_only"}, n2Sets,
+		"n2 replication set order must be preserved")
+}
+
 // In a 3-node mesh, comparing n1 and n2 ignores their subscriptions with n3.
 func TestCompareSubscriptions_IgnoresUnrelatedPeers(t *testing.T) {
 	n1 := spockCfg("n1",

--- a/internal/consistency/diff/spock_diff_test.go
+++ b/internal/consistency/diff/spock_diff_test.go
@@ -1,0 +1,95 @@
+// ///////////////////////////////////////////////////////////////////////////
+//
+// # ACE - Active Consistency Engine
+//
+// Copyright (C) 2023 - 2026, pgEdge (https://www.pgedge.com/)
+//
+// This software is released under the PostgreSQL License:
+// https://opensource.org/license/postgresql
+//
+// ///////////////////////////////////////////////////////////////////////////
+
+package diff
+
+import (
+	"testing"
+
+	"github.com/pgedge/ace/pkg/types"
+	"github.com/stretchr/testify/assert"
+)
+
+// spockCfg is a small helper to build a node config for comparison tests.
+func spockCfg(nodeName string, subs ...types.SpockSubscription) SpockNodeConfig {
+	return SpockNodeConfig{NodeName: nodeName, Subscriptions: subs}
+}
+
+// Healthy reciprocal pair with matching repsets. Names are deliberately
+// arbitrary: matching must rely on the provider node, not a name convention.
+func TestCompareSubscriptions_HealthyReciprocalIgnoresNames(t *testing.T) {
+	n1 := spockCfg("n1", types.SpockSubscription{
+		SubName: "custom_name_a", ProviderNode: "n2", SubEnabled: true,
+		ReplicationSets: []string{"default", "default_insert_only"},
+	})
+	n2 := spockCfg("n2", types.SpockSubscription{
+		SubName: "totally_different", ProviderNode: "n1", SubEnabled: true,
+		ReplicationSets: []string{"default_insert_only", "default"},
+	})
+
+	d := compareSubscriptions(n1, n2)
+
+	assert.Empty(t, d.MissingOnNode1, "n1 subscribes from n2, nothing missing")
+	assert.Empty(t, d.MissingOnNode2, "n2 subscribes from n1, nothing missing")
+	assert.Empty(t, d.Different, "replication sets match (order-insensitive)")
+}
+
+// n1 doesn't subscribe from n2 (one direction missing); n2 does subscribe from n1.
+func TestCompareSubscriptions_MissingOneDirection(t *testing.T) {
+	n1 := spockCfg("n1") // no subscriptions at all
+	n2 := spockCfg("n2", types.SpockSubscription{
+		SubName: "s", ProviderNode: "n1", SubEnabled: true,
+		ReplicationSets: []string{"default"},
+	})
+
+	d := compareSubscriptions(n1, n2)
+
+	assert.Equal(t, []string{"n2"}, d.MissingOnNode1,
+		"n1 should be flagged as not subscribing from n2")
+	assert.Empty(t, d.MissingOnNode2,
+		"n2 correctly subscribes from n1")
+}
+
+// Both directions exist but replication sets differ: reported under Different.
+func TestCompareSubscriptions_DifferentReplicationSets(t *testing.T) {
+	n1 := spockCfg("n1", types.SpockSubscription{
+		SubName: "a", ProviderNode: "n2", SubEnabled: true,
+		ReplicationSets: []string{"default"},
+	})
+	n2 := spockCfg("n2", types.SpockSubscription{
+		SubName: "b", ProviderNode: "n1", SubEnabled: true,
+		ReplicationSets: []string{"default", "extra"},
+	})
+
+	d := compareSubscriptions(n1, n2)
+
+	assert.Empty(t, d.MissingOnNode1)
+	assert.Empty(t, d.MissingOnNode2)
+	assert.Len(t, d.Different, 1, "replication set difference should be reported")
+}
+
+// In a 3-node mesh, comparing n1 and n2 ignores their subscriptions with n3.
+func TestCompareSubscriptions_IgnoresUnrelatedPeers(t *testing.T) {
+	n1 := spockCfg("n1",
+		types.SpockSubscription{SubName: "a", ProviderNode: "n2", SubEnabled: true, ReplicationSets: []string{"default"}},
+		types.SpockSubscription{SubName: "c", ProviderNode: "n3", SubEnabled: true, ReplicationSets: []string{"default"}},
+	)
+	n2 := spockCfg("n2",
+		types.SpockSubscription{SubName: "b", ProviderNode: "n1", SubEnabled: true, ReplicationSets: []string{"default"}},
+		types.SpockSubscription{SubName: "d", ProviderNode: "n3", SubEnabled: true, ReplicationSets: []string{"default"}},
+	)
+
+	d := compareSubscriptions(n1, n2)
+
+	assert.Empty(t, d.MissingOnNode1)
+	assert.Empty(t, d.MissingOnNode2)
+	assert.Empty(t, d.Different)
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -225,7 +225,11 @@ type NodePairDiff struct {
 
 // SpockSubscription holds information about a spock subscription.
 type SpockSubscription struct {
-	SubName         string   `json:"sub_name"`
+	SubName string `json:"sub_name"`
+	// ProviderNode is the spock node_name this subscription replicates FROM
+	// (resolved from sub_origin); used to match reciprocal subscriptions by node
+	// identity instead of by the user-overridable subscription name.
+	ProviderNode    string   `json:"provider_node"`
 	SubEnabled      bool     `json:"sub_enabled"`
 	ReplicationSets []string `json:"replication_sets"`
 }
@@ -316,6 +320,7 @@ type SpockNodeAndSubInfo struct {
 	SubName            string   `db:"sub_name"`
 	SubEnabled         bool     `db:"sub_enabled"`
 	SubReplicationSets []string `db:"sub_replication_sets"`
+	SubOriginName      string   `db:"sub_origin_name"`
 }
 
 // SpockRepSetInfo contains information about a replication set.

--- a/tests/integration/spock_diff_test.go
+++ b/tests/integration/spock_diff_test.go
@@ -1,0 +1,96 @@
+// ///////////////////////////////////////////////////////////////////////////
+//
+// # ACE - Active Consistency Engine
+//
+// Copyright (C) 2023 - 2026, pgEdge (https://www.pgedge.com/)
+//
+// This software is released under the PostgreSQL License:
+// https://opensource.org/license/postgresql
+//
+// ///////////////////////////////////////////////////////////////////////////
+
+package integration
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pgedge/ace/db/queries"
+	"github.com/pgedge/ace/internal/consistency/diff"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression for issue #124: spock.node.node_id / spock.subscription.sub_id are
+// `oid` columns and fail to scan into int64 in the binary protocol. Needs a real
+// spock cluster with rows; the native-PG "spock not installed" test never reaches
+// this scan.
+func TestGetSpockNodeAndSubInfo_ScansOIDColumns(t *testing.T) {
+	ctx := context.Background()
+
+	infos, err := queries.GetSpockNodeAndSubInfo(ctx, pgCluster.Node1Pool)
+	require.NoError(t, err,
+		"scanning spock.node/spock.subscription must not fail on oid columns")
+
+	// The mesh guarantees rows; without them the scan path wouldn't run and the
+	// test would pass even with the bug present.
+	require.NotEmpty(t, infos,
+		"expected subscription rows on a spock mesh node")
+
+	for _, info := range infos {
+		assert.NotZero(t, info.NodeID, "node_id should be populated")
+		assert.NotEmpty(t, info.NodeName, "node_name should be populated")
+		assert.NotEmpty(t, info.SubName, "sub_name should be populated (query filters NULLs)")
+	}
+}
+
+// End-to-end regression for issue #124: the full `ace spock-diff` command path
+// must complete against a real spock cluster (it previously failed at the first
+// GetSpockNodeAndSubInfo call).
+func TestSpockDiff_SucceedsOnSpockCluster(t *testing.T) {
+	t.Cleanup(func() {
+		files, err := filepath.Glob("spock_diffs-*.json")
+		if err != nil {
+			t.Logf("failed to glob spock diff artifacts: %v", err)
+			return
+		}
+		for _, f := range files {
+			if err := os.Remove(f); err != nil {
+				t.Logf("failed to remove %s: %v", f, err)
+			}
+		}
+	})
+
+	task := diff.NewSpockDiffTask()
+	task.ClusterName = pgCluster.ClusterName
+	task.DBName = dbName
+	task.Nodes = serviceN1 + "," + serviceN2
+	task.Ctx = context.Background()
+	task.SkipDBUpdate = true
+
+	require.NoError(t, task.RunChecks(false),
+		"spock-diff RunChecks should connect to the spock nodes")
+
+	require.NoError(t, task.ExecuteTask(),
+		"spock-diff must complete against a spock-enabled cluster")
+
+	// Both selected nodes should have had their spock config fetched and scanned.
+	require.Contains(t, task.DiffResult.SpockConfigs, serviceN1)
+	require.Contains(t, task.DiffResult.SpockConfigs, serviceN2)
+
+	// Two selected nodes yield exactly one comparison pair.
+	require.Len(t, task.DiffResult.Diffs, 1,
+		"expected a single %s/%s comparison", serviceN1, serviceN2)
+
+	// Healthy bidirectional mesh: matching reciprocal subscriptions by node
+	// identity (not name) must report no mismatch. The old name-pattern logic
+	// produced false "missing subscription" diffs here.
+	for pair, d := range task.DiffResult.Diffs {
+		assert.False(t, d.Mismatch,
+			"healthy mesh pair %s should report no differences, got: %+v", pair, d.Details)
+		assert.Empty(t, d.Details.Subscriptions.MissingOnNode1, "pair %s", pair)
+		assert.Empty(t, d.Details.Subscriptions.MissingOnNode2, "pair %s", pair)
+	}
+}


### PR DESCRIPTION
Three distinct bugs prevented spock-diff from working on a spock cluster:

- GetSpockNodeAndSubInfo scanned the oid columns spock.node.node_id and spock.subscription.sub_id into int64, failing with "cannot scan oid (OID 26) in binary format into *int64". Cast both to bigint.
- GetSpockRepSetInfo scanned NULL set_name (tables in no replication set) into a non-nullable string. Filter NULLs in the query.
- compareSubscriptions matched reciprocal subscriptions by reconstructing sub_<a><b> names, which breaks for user-renamed subscriptions and had the direction backwards. Resolve each subscription's origin node (sub_origin) and match reciprocal pairs by node identity instead.

Add unit tests for the comparison logic and integration tests that run the full command against the spock cluster, and wire both into CI.