### PR TITLE
Speed up `mtree table-diff` by fixing CDC-drain overhead

### DIFF
--- a/internal/consistency/mtree/merkle.go
+++ b/internal/consistency/mtree/merkle.go
@@ -1598,9 +1598,28 @@ func (m *MerkleTreeTask) UpdateMtree(skipAllChecks bool) (err error) {
 		ctx, cancel := context.WithTimeout(baseCtx, timeout)
 		defer cancel()
 
-		for _, nodeInfo := range m.ClusterNodes {
-			if err := cdc.UpdateFromCDC(ctx, nodeInfo); err != nil {
-				return fmt.Errorf("CDC update failed for node %s: %w", nodeInfo["Name"], err)
+		// Drain each node's CDC stream concurrently. Each UpdateFromCDC targets
+		// a distinct node over its own connection and writes only that node's
+		// CDC metadata, so the calls are independent. Draining sequentially
+		// made every mtree update/diff pay the per-node drain latency once per
+		// node; running them together collapses that to roughly a single
+		// drain's wall-clock. Errors are collected per node and the first
+		// (in node order) is returned, preserving the prior semantics.
+		var wg sync.WaitGroup
+		cdcErrs := make([]error, len(m.ClusterNodes))
+		for i, nodeInfo := range m.ClusterNodes {
+			wg.Add(1)
+			go func(i int, nodeInfo map[string]any) {
+				defer wg.Done()
+				if err := cdc.UpdateFromCDC(ctx, nodeInfo); err != nil {
+					cdcErrs[i] = fmt.Errorf("CDC update failed for node %s: %w", nodeInfo["Name"], err)
+				}
+			}(i, nodeInfo)
+		}
+		wg.Wait()
+		for _, e := range cdcErrs {
+			if e != nil {
+				return e
 			}
 		}
 	}

--- a/internal/infra/cdc/listen.go
+++ b/internal/infra/cdc/listen.go
@@ -321,6 +321,19 @@ func processReplicationStream(ctx context.Context, nodeInfo map[string]any, cont
 					}
 				}
 
+				// ServerWALEnd is the server's "I have sent you everything up
+				// to here" marker. Replication messages arrive in LSN order, so
+				// once a keepalive reports ServerWALEnd >= targetFlushLSN every
+				// committed change up to the target has already been delivered
+				// (and queued for apply, which wg.Wait below awaits). Stopping
+				// here avoids waiting out the 1s idle timeout in the common case
+				// where the tracked table did not change but other tables did,
+				// so no data message ever reaches the target LSN.
+				if !continuous && targetFlushLSN != 0 && pkm.ServerWALEnd >= targetFlushLSN {
+					logger.Info("Server caught up to target WAL flush LSN %s via keepalive; stopping replication stream", targetFlushLSN)
+					stopStreaming = true
+				}
+
 			case pglogrepl.XLogDataByteID:
 				xld, err := pglogrepl.ParseXLogData(msg.Data[1:])
 				if err != nil {


### PR DESCRIPTION
### Problem
`mtree table-diff` was reported ~2x slower than plain `table-diff` on a 499,999-row, 3-node cluster. `mtree table-diff` first reconciles each node's cached Merkle tree with current data by draining that node's CDC (Change Data Capture) stream (`UpdateMtree`); `table-diff` reads the live tables directly and has no cache to refresh, so it never drains. The drain was paying two avoidable costs on every diff:

1. **Sequential per-node drain.** Each node's CDC stream was drained one after another. With N nodes that multiplied the per-node drain latency N times.
2. **Idle-timeout termination.** In non-continuous mode the drain stopped only when it reached the target LSN *via a data message*, or after a ~1s idle receive-timeout. Because the publication streams only the tracked table, any unrelated WAL activity advances the global flush LSN while the table itself sees no data messages — so the "reached target" path rarely fires and the drain falls through to the full ~1s idle wait. This was paid **per node, on every diff, even when nothing relevant had changed**.

On a 3-node cluster that is a ~3s fixed floor (3 × ~1s) on every `mtree table-diff`, independent of whether anything changed — which is exactly why a brute-force `table-diff` could finish first.

### Changes
1. **Drain CDC streams concurrently across nodes** (`internal/consistency/mtree/merkle.go`). Each `UpdateFromCDC` targets a distinct node over its own connection and writes only that node's CDC metadata, so the calls are independent. They now run concurrently; per-node errors are collected and the first (in node order) is returned, preserving prior semantics. Collapses N sequential drains into ~one drain's wall-clock.
2. **Stop the drain promptly at the target LSN** (`internal/infra/cdc/listen.go`). PostgreSQL keepalive messages carry `ServerWALEnd` ("I have sent you everything up to here"). When `ServerWALEnd >= targetFlushLSN` we are caught up and stop immediately, instead of waiting out the ~1s idle timeout. This is the correct catch-up signal for a publication-filtered stream (where the target often can't be reached via table data messages). Applies to non-continuous drains only; the long-running listener is unchanged.

Safety of (2): replication messages arrive in LSN order, so a keepalive past the target arrives only after every data message ≤ target was already delivered; received changes are applied in goroutines that the post-loop `wg.Wait()`/`metaWg.Wait()` await before returning, so setting the stop flag cannot drop a received change.

### Correctness
`table-diff` path is not touched. The full mtree + CDC integration suites — including the under-reporting guards (`TestUpdateMtreeReflectsInserts/Deletes/Updates`, bidirectional/3-node diffs) and the CDC/slot tests — pass under `go test -race`.

### Not in this PR
A follow-up `bounded-drain` / `--quick` mode (cap the drain when the WAL backlog is large, report per-node staleness, and gate `table-repair` from acting on an incomplete diff) is proposed separately; it targets the widespread/large-backlog case this PR does not fully close.