### PR TITLE
Reveal consumed positional when cluster name is missing

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -865,6 +865,16 @@ func resolveClusterArg(cmd, missingUsage, argsUsage string, required int, args [
 	if len(args) == required {
 		cluster := config.DefaultCluster()
 		if cluster == "" {
+			if required > 0 {
+				// The positional(s) supplied were consumed as the required
+				// entity (e.g. <repset>), leaving the cluster unset. Spell that
+				// out so a lone argument isn't silently misread as the cluster
+				// and reported back as a bare "cluster name is required".
+				return "", nil, fmt.Errorf(
+					"cluster name is required: %q was read as the %s argument (usage: %s %s); "+
+						"pass the cluster as the first argument or set default_cluster in ace.yaml",
+					strings.Join(args, " "), missingUsage, cmd, argsUsage)
+			}
 			return "", nil, fmt.Errorf("cluster name is required: specify one explicitly or set default_cluster in ace.yaml")
 		}
 		return cluster, args, nil

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -13,6 +13,7 @@ package cli
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/pgedge/ace/pkg/config"
@@ -58,6 +59,25 @@ func TestResolveClusterArgErrorsWithoutDefault(t *testing.T) {
 
 	if _, _, err := resolveClusterArg("table-rerun", "", "[cluster]", 0, []string{}); err == nil {
 		t.Fatalf("expected error when no cluster and no default configured")
+	}
+}
+
+// A lone positional is consumed as the required entity (repset), not the
+// cluster. The error must name the consumed argument so the user sees why
+// "cluster name is required" fired, instead of thinking their argument was
+// ignored.
+func TestResolveClusterArgSinglePositionalRevealsConsumedArg(t *testing.T) {
+	t.Cleanup(func() { config.Cfg = nil })
+	config.Cfg = &config.Config{}
+
+	_, _, err := resolveClusterArg("repset-diff", "<repset>", "[cluster] <repset>", 1, []string{"demo"})
+	if err == nil {
+		t.Fatalf("expected error for a lone positional with no default_cluster set")
+	}
+	for _, want := range []string{"demo", "<repset>", "repset-diff"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing expected substring %q", err.Error(), want)
+		}
 	}
 }
 


### PR DESCRIPTION
Reveal consumed positional when cluster name is missing