### PR TITLE
feat(cli): add --version flag

### DIFF
--- a/cmd/ace/main.go
+++ b/cmd/ace/main.go
@@ -78,7 +78,8 @@ func shouldSkipConfig(args []string) bool {
 	}
 
 	for _, arg := range args {
-		if arg == "--help" || arg == "-h" || arg == "help" {
+		if arg == "--help" || arg == "-h" || arg == "help" ||
+			arg == "--version" || arg == "-V" {
 			return true
 		}
 	}

--- a/cmd/ace/main.go
+++ b/cmd/ace/main.go
@@ -22,6 +22,11 @@ import (
 	"github.com/pgedge/ace/pkg/logger"
 )
 
+// version is the ACE release version. It defaults to the value below for
+// local builds and is overridden at release time via -ldflags "-X main.version=..."
+// (see .goreleaser.yaml).
+var version = "2.1.0"
+
 func main() {
 	var cfgPath string
 	if !shouldSkipConfig(os.Args[1:]) {
@@ -60,7 +65,7 @@ func main() {
 		}
 	}
 
-	app := cli.SetupCLI()
+	app := cli.SetupCLI(version)
 	err := app.Run(context.Background(), os.Args)
 	if err != nil {
 		logger.Error("%v", err)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -43,7 +43,15 @@ var defaultConfigYAML string
 //go:embed default_pg_service.conf
 var defaultPgServiceConf string
 
-func SetupCLI() *cli.Command {
+func SetupCLI(version string) *cli.Command {
+	// Use -V (not the urfave default -v) for version, so -v stays reserved for
+	// the debug/verbose flag on subcommands (matching go tooling conventions).
+	cli.VersionFlag = &cli.BoolFlag{
+		Name:    "version",
+		Aliases: []string{"V"},
+		Usage:   "print the version",
+	}
+
 	commonFlags := []cli.Flag{
 		&cli.StringFlag{
 			Name:    "dbname",
@@ -433,8 +441,9 @@ func SetupCLI() *cli.Command {
 	}
 
 	app := &cli.Command{
-		Name:  "ace",
-		Usage: "ACE - Active Consistency Engine",
+		Name:    "ace",
+		Usage:   "ACE - Active Consistency Engine",
+		Version: version,
 		Commands: []*cli.Command{
 			{
 				Name:  "config",


### PR DESCRIPTION
Leverage urfave/cli/v3's built-in Version support by setting the root command's Version field. Default is 2.1.0, overridden at release time via the existing goreleaser -X main.version ldflag.

We support --version or -V for version.
Note that -v (lower case) is a convention for debug mode. It works with subcommands, but not the top level "ace -v" alone.