### PR TITLE
fix(release): mark pre-release tags as GitHub pre-releases

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,6 +45,12 @@ changelog:
       - "^test:"
 
 release:
+  # Mark tags carrying a semver pre-release component (-rc.N, -beta, -alpha)
+  # as GitHub pre-releases so they're excluded from the "Latest" badge and
+  # sort below the newest GA release. Without this, GoReleaser's default
+  # (prerelease: false) publishes rc/beta tags as full releases, which GitHub
+  # then stamps "Latest" and pins to the top of the releases list.
+  prerelease: auto
   footer: >-
 
     ---


### PR DESCRIPTION
GoReleaser's default (prerelease: false) publishes rc/beta/alpha tags as full GitHub releases, so GitHub stamps them "Latest" and pins them above the GA release in the releases list. Set prerelease: auto so tags with a semver pre-release component are flagged as pre-releases, matching the rc*/beta*/alpha* suffix routing already in release.yaml.