### PR TITLE
Fix UUID primary keys, and stop reporting a match it never established

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,9 @@ jobs:
     - name: Run mtree uuid primary-key test
       run: go test -count=1 -v ./tests/integration -run 'TestMtreeUUIDPrimaryKeyDiff'
 
+    - name: Run mtree primary-key type property test
+      run: go test -count=1 -v ./tests/integration -run 'TestMtreePkeyTypesFindDivergence'
+
 
     - name: Run CDC regression tests
       run: go test -count=1 -v ./tests/integration -run 'CDC'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,8 +40,15 @@ jobs:
     - name: Run mtree unit tests
       run: go test -count=1 -v ./internal/consistency/mtree
 
+    - name: Run common unit tests
+      run: go test -count=1 -v ./pkg/common
+
     - name: Run mtree missing-tree fail-fast test
       run: go test -count=1 -v ./tests/integration -run 'TestMtreeDiffFailsFastWhenTreeNotBuilt'
+
+    - name: Run mtree uuid primary-key test
+      run: go test -count=1 -v ./tests/integration -run 'TestMtreeUUIDPrimaryKeyDiff'
+
 
     - name: Run CDC regression tests
       run: go test -count=1 -v ./tests/integration -run 'CDC'

--- a/docs/commands/mtree/mtree-table-diff.md
+++ b/docs/commands/mtree/mtree-table-diff.md
@@ -52,6 +52,15 @@ holding the node's slot, then re-run, if you need a guaranteed-current drain.
   warning is logged. This keeps a heavily diverged table from exhausting memory;
   lower the value in `ace.yaml` on memory-constrained hosts, and re-run after
   repairing to surface the remaining differences.
+- Merkle trees do not order every primary key type the way the server does. `text`
+  keys are compared byte by byte, so a collation other than `C`, and also `enum`
+  or `citext` keys, can sort differently here than in the database; `numeric` and
+  the types the driver decodes into a struct are not ordered correctly at all.
+  When the two orders disagree, some blocks are skipped and the diff reports
+  fewer differences than exist. Use `table-diff` for those tables: it does not
+  sort block bounds outside the database. See
+  [Primary Key Types and the Postgres Type Boundary](../../design/merkle.md#primary-key-types-and-the-postgres-type-boundary)
+  for the full list and the reasons.
 - When *all* mismatched blocks between a node pair turn out to hold no row
   differences, the tree hashes were stale rather than the data divergent. The
   diff reports this, refreshes those blocks from live data (recorded in the

--- a/docs/design/merkle.md
+++ b/docs/design/merkle.md
@@ -353,6 +353,77 @@ Notes:
 - **Mtree-specific tuning knobs**: `max_cpu_ratio` influences worker count and pool sizing; `batch_size` controls how many ranges are compared per DB round-trip in diffs. Higher values increase throughput but raise DB and network load.
 - **Error handling**: If splits/merges or parent rebuilds fail (e.g., type issues, missing metadata), `update`/`diff` aborts; the remedy is usually to fix the schema/state and rerun, or rebuild the tree when metadata and actual table diverge.
 
+### Primary Key Types and the Postgres Type Boundary
+
+ACE hashes and compares rows inside Postgres, but it decides *which* rows to
+compare in Go. It reads the block bounds out of the tree, sorts and merges them
+in the ACE process, then sends them back as parameters of the next query. So
+every primary key value crosses from one type system into the other. On the Go
+side it is no longer a Postgres value: it is whatever the driver turned it into.
+
+That conversion loses information in three ways, and ACE has hit all three:
+
+- **Representation.** What the driver returns is not always something it will
+  take back. A `uuid` comes back as a plain `[16]byte`, which Go prints as
+  `[17 17 ...]`. Used as a query parameter, that gives
+  `invalid input syntax for type uuid`. Any value that ACE reads from
+  a tree and sends back as a bound has to survive this round trip.
+- **Ordering.** Postgres cuts the blocks with `ORDER BY <pkey>`, but ACE merges
+  and sorts the bounds of the mismatched blocks in Go. The two orders agree only
+  when the btree order of the type is also the natural Go order for the decoded
+  value. When they do not agree, some pairs of neighbouring bounds end up the
+  wrong way round and the range condition selects no rows, so those blocks are
+  never compared and the diff under-reports. The loss is partial and depends on
+  the data: measured on PostgreSQL 17 with 9 differing rows, restoring the
+  pre-fix uuid ordering reported 6 of them, and a `text` key in `en_US.utf8`
+  reported 4. A wrong order often only widens a range instead of emptying it,
+  which is why this shows up as quietly missing rows rather than as an error.
+- **Identity.** Postgres can treat two values as equal where Go sees two
+  different ones. In `numeric`, `1.5` and `1.50` are the same value for the
+  database, but the driver returns two different `(digits, exponent)` pairs. Row
+  hashing already handles this, because it casts through `trim_scale(...)::text`.
+  Bounds do not go through that cast.
+
+So a Merkle tree only works over a primary key whose values ACE can sort and
+rebuild correctly outside the database:
+
+| Primary key type | Status in `mtree` |
+|---|---|
+| `smallint`, `integer`, `bigint`, `real`, `double precision`, `boolean` | Supported |
+| `uuid`, `bytea` | Supported; compared as bytes, like `uuid_cmp` and `byteacmp` |
+| `timestamp`, `timestamptz`, `date` | Supported |
+| `text`, `varchar`, `char` | Supported **only under the `C` or `POSIX` collation**; see below |
+| `numeric`, `time`, and any type the driver decodes into a struct | **Not supported**: ordered by their Go rendering, which bears no relation to the Postgres order |
+| `enum`, `citext`, domains over any of the above, and types the driver has no codec for | Accepted, but the order is not guaranteed; see below |
+
+Nothing stops a tree being built over an unsupported type today; the bounds are
+simply ordered by their Go rendering and the diff can then under-report. A
+follow-up turns that into a refusal, on the grounds that a consistency checker
+which cannot produce a result has to say so: reporting "no differences" after
+quietly comparing an empty range is worse, because nobody can tell that apart
+from a real match.
+
+The last two rows of the table is a known gap, not a supported setup, and it is
+reproducible: `tests/integration/mtree_pkey_types_test.go` carries a case for
+it, skipped until the fix lands. A `text` primary key in any collation other
+than `C` sorts differently in the database than byte by byte in Go: under
+`en_US.UTF-8` the database puts `'a'` before `'B'`, while ACE puts `'B'` first.
+How much that costs depends on the keys -- the same collation over hex strings
+loses nothing, while keys that alternate case lost 5 of 9 differing rows in
+testing -- so a run that finds differences is not evidence that it found all of
+them. An `enum` sorts by `enumsortorder` and not by
+its label, but it reaches ACE as a plain string. The same is true for any type
+the driver has no codec for: it arrives as raw bytes or as text and is compared
+byte by byte, which need not be the order the type really uses. ACE does not
+detect any of this today. The proper fix is to sort the bounds in SQL instead of
+in Go, which removes the whole group of problems at once. Adding more comparison
+cases in Go only makes more types look supported than they are.
+
+`table-diff` has none of these problems, because it never sorts or merges block
+bounds in Go. It stays the fallback for a table whose primary key `mtree`
+cannot sort reliably.
+
+### Observability and Teardown
 ### Observability and Teardown
 - **Task records**: Mtree runs are recorded in `ace_tasks.db` (table `ace_tasks`) with context about block size, nodes, and statuses. Check logs for counts of dirty blocks, splits/merges applied, parent rebuilds, and extra-leaf mismatches during diff traversal.
 - **Slot health**: Monitor logical slot lag/WAL retention; a bloated slot suggests `update` hasn’t consumed changes. If the slot is dropped or stale, rebuild (init + build) and recreate the slot/publication entry.

--- a/docs/design/merkle.md
+++ b/docs/design/merkle.md
@@ -393,17 +393,29 @@ rebuild correctly outside the database:
 | `uuid`, `bytea` | Supported; compared as bytes, like `uuid_cmp` and `byteacmp` |
 | `timestamp`, `timestamptz`, `date` | Supported |
 | `text`, `varchar`, `char` | Supported **only under the `C` or `POSIX` collation**; see below |
-| `numeric`, `time`, and any type the driver decodes into a struct | **Not supported**: ordered by their Go rendering, which bears no relation to the Postgres order |
+| `numeric`, `time`, and any type the driver decodes into a struct | **Not supported.** The tree builds and a clean run still reports a match, but the moment a block mismatches, the row identity cannot be built and the comparison stops with an error |
 | `enum`, `citext`, domains over any of the above, and types the driver has no codec for | Accepted, but the order is not guaranteed; see below |
 
-Nothing stops a tree being built over an unsupported type today; the bounds are
-simply ordered by their Go rendering and the diff can then under-report. A
-follow-up turns that into a refusal, on the grounds that a consistency checker
-which cannot produce a result has to say so: reporting "no differences" after
-quietly comparing an empty range is worse, because nobody can tell that apart
-from a real match.
+The two halves of that table fail differently, and the difference matters.
 
-The last two rows of the table is a known gap, not a supported setup, and it is
+A type the driver decodes into a struct -- `numeric`, `time` -- has no row
+identity ACE can build, so as soon as a block mismatches and the rows have to be
+matched up, the comparison stops with an error. The pair is recorded in
+`incomplete_pairs`, `TABLES MATCH` is not printed, and the command exits
+non-zero. Nothing is silently dropped, but note what is *not* covered: a run
+that finds no mismatching block at all still reports a match, and the bounds
+that led to that conclusion were ordered by their Go rendering. A clean verdict
+over such a key is worth no more than the ordering behind it.
+
+A string-like type whose collation Go cannot reproduce -- `text` outside `C`,
+`enum`, `citext` -- is the worse case, because identity works fine and only the
+*order* is wrong. There is nothing to refuse and nothing to report: the run
+completes, prints a verdict, and can be missing rows. A warning naming the type
+is logged once per task when the comparator meets a type it cannot order, but
+that warning does not fire for these, because Go will happily compare two
+strings.
+
+That second half is a known gap, not a supported setup, and it is
 reproducible: `tests/integration/mtree_pkey_types_test.go` carries a case for
 it, skipped until the fix lands. A `text` primary key in any collation other
 than `C` sorts differently in the database than byte by byte in Go: under

--- a/docs/design/merkle.md
+++ b/docs/design/merkle.md
@@ -424,7 +424,6 @@ bounds in Go. It stays the fallback for a table whose primary key `mtree`
 cannot sort reliably.
 
 ### Observability and Teardown
-### Observability and Teardown
 - **Task records**: Mtree runs are recorded in `ace_tasks.db` (table `ace_tasks`) with context about block size, nodes, and statuses. Check logs for counts of dirty blocks, splits/merges applied, parent rebuilds, and extra-leaf mismatches during diff traversal.
 - **Slot health**: Monitor logical slot lag/WAL retention; a bloated slot suggests `update` hasn’t consumed changes. If the slot is dropped or stale, rebuild (init + build) and recreate the slot/publication entry.
 - **Teardown/reset**: Prefer the built-in `teardown`/`teardown-table` commands to remove mtree artifacts (mtree table, composite type, metadata, publication entry). Use manual drops only if automation fails, then rebuild with the desired block size and resume CDC.

--- a/internal/consistency/mtree/merkle.go
+++ b/internal/consistency/mtree/merkle.go
@@ -13,6 +13,7 @@ package mtree
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"maps"
@@ -21,6 +22,7 @@ import (
 	"reflect"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -441,26 +443,28 @@ func (m *MerkleTreeTask) processWorkItem(work CompareRangesWorkItem, pool1, pool
 	mismatchedComposite := make([][]any, 0)
 	isComposite := !m.SimplePrimaryKey
 
+	// Use the scanned pkey values, never the map key: the key is only a
+	// printed form and loses information.
 	if isComposite {
-		for k, h1 := range node1Hashes {
-			if h2, ok := node2Hashes[k]; !ok || h1 != h2 {
-				mismatchedComposite = append(mismatchedComposite, splitCompositeKey(k))
+		for k, e1 := range node1Hashes {
+			if e2, ok := node2Hashes[k]; !ok || e1.hash != e2.hash {
+				mismatchedComposite = append(mismatchedComposite, e1.pkey)
 			}
 		}
-		for k, h2 := range node2Hashes {
-			if h1, ok := node1Hashes[k]; !ok || h1 != h2 {
-				mismatchedComposite = append(mismatchedComposite, splitCompositeKey(k))
+		for k, e2 := range node2Hashes {
+			if e1, ok := node1Hashes[k]; !ok || e1.hash != e2.hash {
+				mismatchedComposite = append(mismatchedComposite, e2.pkey)
 			}
 		}
 	} else {
-		for k, h1 := range node1Hashes {
-			if h2, ok := node2Hashes[k]; !ok || h1 != h2 {
-				mismatchedSimple = append(mismatchedSimple, k)
+		for k, e1 := range node1Hashes {
+			if e2, ok := node2Hashes[k]; !ok || e1.hash != e2.hash {
+				mismatchedSimple = append(mismatchedSimple, e1.pkey[0])
 			}
 		}
-		for k, h2 := range node2Hashes {
-			if h1, ok := node1Hashes[k]; !ok || h1 != h2 {
-				mismatchedSimple = append(mismatchedSimple, k)
+		for k, e2 := range node2Hashes {
+			if e1, ok := node1Hashes[k]; !ok || e1.hash != e2.hash {
+				mismatchedSimple = append(mismatchedSimple, e2.pkey[0])
 			}
 		}
 	}
@@ -814,9 +818,106 @@ func buildRowHashQuery(schema, table string, key []string, cols []string, whereC
 	return query, orderBy
 }
 
-func readRowHashes(rows pgx.Rows, numPK int) (map[string]string, error) {
+// pkeyKind classifies a primary-key value that pgx decoded into an untyped
+// destination. It is the one list of what mtree can handle, and three things
+// have to agree with it: comparePkeyValues sorts these kinds, pkeyIdentity
+// renders them, and validateBoundaryTypes admits them. Nothing in the language
+// ties the three together, so TestPkeyKindsAreFullySupported does.
+//
+// A kind is on the list only if Go can reproduce the Postgres btree order for
+// it, and if two different values always render differently. Adding a kind
+// without both properties brings back a silent wrong answer -- see
+// compareBoundaries' KNOWN GAP for the cases already on the list that only
+// hold under some collations.
+type pkeyKind int
+
+const (
+	pkeyUnsupported pkeyKind = iota
+	pkeyInt
+	pkeyUint
+	pkeyFloat
+	pkeyBool
+	pkeyString
+	pkeyTime
+	pkeyUUID  // pgx decodes uuid as [16]byte
+	pkeyBytes // bytea
+)
+
+func pkeyKindOf(v any) pkeyKind {
+	switch v.(type) {
+	case int, int8, int16, int32, int64:
+		return pkeyInt
+	case uint, uint8, uint16, uint32, uint64:
+		return pkeyUint
+	case float32, float64:
+		return pkeyFloat
+	case bool:
+		return pkeyBool
+	case string:
+		return pkeyString
+	case time.Time:
+		return pkeyTime
+	case [16]byte:
+		return pkeyUUID
+	case []byte:
+		return pkeyBytes
+	}
+	return pkeyUnsupported
+}
+
+// pkeyIdentity renders one primary-key value for use as a row key. The result
+// only has to be injective -- two different values must never render the same
+// -- and stable within a run, because both nodes render with this same code.
+//
+// It exists so that row identity does not depend on fmt: a %v of a driver
+// value is not part of any contract, it changes with the driver, and for a
+// type that prints a pointer it would make two runs disagree about which rows
+// are "the same". ok is false for a kind mtree does not support.
+func pkeyIdentity(v any) (string, bool) {
+	switch pkeyKindOf(v) {
+	case pkeyInt:
+		return strconv.FormatInt(reflect.ValueOf(v).Int(), 10), true
+	case pkeyUint:
+		return strconv.FormatUint(reflect.ValueOf(v).Uint(), 10), true
+	case pkeyFloat:
+		// 'x' is the exact hexadecimal form: no rounding, so no two distinct
+		// float values collide here. Add zero first: Postgres holds -0.0 = 0.0,
+		// but they have different bit patterns and would otherwise get two
+		// identities, splitting one row into two.
+		return strconv.FormatFloat(reflect.ValueOf(v).Float()+0, 'x', -1, 64), true
+	case pkeyBool:
+		return strconv.FormatBool(v.(bool)), true
+	case pkeyString:
+		return v.(string), true
+	case pkeyTime:
+		return v.(time.Time).UTC().Format("2006-01-02T15:04:05.999999999Z"), true
+	case pkeyUUID:
+		u := v.([16]byte)
+		return hex.EncodeToString(u[:]), true
+	case pkeyBytes:
+		return hex.EncodeToString(v.([]byte)), true
+	}
+	return "", false
+}
+
+// rowHashEntry holds a row's hash together with the pkey values it was built
+// from. Keep pkey: the map key is only a printed form, and rebuilding pkey
+// values from it is what broke uuid keys. pkey points into the scan
+// buffer of readRowHashes, so that buffer has to be allocated inside the loop.
+// Moving the allocation out of the loop would make every entry point at the
+// last row.
+type rowHashEntry struct {
+	hash string
+	pkey []any
+}
+
+// readRowHashes runs once for every row of a mismatched block, so up to
+// mtree.max_block_size times per node per work item. The three allocations
+// below sit on that hot path; pkey points into scan instead of copying it,
+// which is what keeps the count at three.
+func readRowHashes(rows pgx.Rows, numPK int) (map[string]rowHashEntry, error) {
 	defer rows.Close()
-	result := make(map[string]string)
+	result := make(map[string]rowHashEntry)
 	for rows.Next() {
 		scan := make([]any, numPK+1)
 		scanPtrs := make([]any, numPK+1)
@@ -826,30 +927,31 @@ func readRowHashes(rows pgx.Rows, numPK int) (map[string]string, error) {
 		if err := rows.Scan(scanPtrs...); err != nil {
 			return nil, err
 		}
+		// Point into the scan buffer instead of copying it: a mismatched block
+		// can hold up to mtree.max_block_size rows, and this map stays in
+		// memory for the whole work item, on both nodes at once. Limit the
+		// capacity so that an append here cannot reach the hash slot after it.
+		pkey := scan[:numPK:numPK]
 		parts := make([]string, numPK)
 		for i := 0; i < numPK; i++ {
-			parts[i] = fmt.Sprintf("%v", scan[i])
+			id, ok := pkeyIdentity(scan[i])
+			if !ok {
+				return nil, fmt.Errorf("primary-key value of type %T cannot be used "+
+					"as a row identity; mtree does not support this column type", scan[i])
+			}
+			parts[i] = id
 		}
-		key := strings.Join(parts, "|")
+		// The key identifies a row across nodes and nothing else. It is NOT a
+		// pkey value and must never reach SQL, a diff report or repair: use
+		// rowHashEntry.pkey for those.
+		key := utils.RowKeyFromStrings(parts)
 		h, _ := scan[numPK].(string)
-		result[key] = h
+		result[key] = rowHashEntry{hash: h, pkey: pkey}
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
 	return result, nil
-}
-
-func splitCompositeKey(k string) []any {
-	if k == "" {
-		return []any{}
-	}
-	parts := strings.Split(k, "|")
-	res := make([]any, len(parts))
-	for i := range parts {
-		res[i] = parts[i]
-	}
-	return res
 }
 
 func buildFetchRowsSQLSimple(schema, table, pk, selectCols, orderBy string, keys []any) (string, []any) {
@@ -2407,9 +2509,12 @@ func (m *MerkleTreeTask) DiffMtree() (err error) {
 		if m.DiffResult.Summary.DiffRowLimitReached {
 			logger.Warn("mtree table-diff stopped after reaching max_diff_rows=%d; additional differences may exist", m.MaxDiffRows)
 		}
-		if diffPath, _, writeErr := utils.WriteDiffReport(m.DiffResult, m.Schema, m.Table, m.Output); writeErr != nil {
+
+		diffPath, _, writeErr := utils.WriteDiffReport(m.DiffResult, m.Schema, m.Table, m.Output)
+		if writeErr != nil {
 			return writeErr
-		} else if diffPath != "" {
+		}
+		if diffPath != "" {
 			resultCtx["diff_file"] = diffPath
 		}
 	}

--- a/internal/consistency/mtree/merkle.go
+++ b/internal/consistency/mtree/merkle.go
@@ -12,6 +12,7 @@
 package mtree
 
 import (
+	"cmp"
 	"context"
 	"encoding/hex"
 	"errors"
@@ -863,6 +864,55 @@ func pkeyKindOf(v any) pkeyKind {
 		return pkeyBytes
 	}
 	return pkeyUnsupported
+}
+
+// comparePkeyValues orders two primary-key values of the same Go type, the way
+// the server orders that type. ok is false for a kind pkeyKindOf does not
+// know; the caller has to decide what to do about it.
+func comparePkeyValues(val1, val2 any) (result int, ok bool) {
+	switch pkeyKindOf(val1) {
+	case pkeyInt:
+		return cmp.Compare(reflect.ValueOf(val1).Int(), reflect.ValueOf(val2).Int()), true
+	case pkeyUint:
+		// Postgres has no unsigned integers, so this is unreachable through a
+		// real pkey. It is here because reflect.Value.Int() panics on a uint
+		// kind, and lumping the two together used to risk exactly that.
+		return cmp.Compare(reflect.ValueOf(val1).Uint(), reflect.ValueOf(val2).Uint()), true
+	case pkeyFloat:
+		// Postgres sorts NaN above every number in a float btree; Go's
+		// cmp.Compare puts it below. NaN is a legal pkey value, so follow the
+		// server or the bounds around it come out inverted.
+		a, b := reflect.ValueOf(val1).Float(), reflect.ValueOf(val2).Float()
+		switch aNaN, bNaN := math.IsNaN(a), math.IsNaN(b); {
+		case aNaN && bNaN:
+			return 0, true
+		case aNaN:
+			return 1, true
+		case bNaN:
+			return -1, true
+		}
+		return cmp.Compare(a, b), true
+	case pkeyBool:
+		a, b := val1.(bool), val2.(bool)
+		if a == b {
+			return 0, true
+		}
+		if b {
+			return -1, true
+		}
+		return 1, true
+	case pkeyString:
+		return cmp.Compare(val1.(string), val2.(string)), true
+	case pkeyTime:
+		return val1.(time.Time).Compare(val2.(time.Time)), true
+	case pkeyUUID:
+		// uuid_cmp() and byteacmp() compare bytes, so compare bytes here too.
+		a, b := val1.([16]byte), val2.([16]byte)
+		return bytes.Compare(a[:], b[:]), true
+	case pkeyBytes:
+		return bytes.Compare(val1.([]byte), val2.([]byte)), true
+	}
+	return 0, false
 }
 
 // pkeyIdentity renders one primary-key value for use as a row key. The result
@@ -2788,6 +2838,23 @@ func (m *MerkleTreeTask) getPkeyBatches(pool1, pool2 *pgxpool.Pool, mismatchedPo
 	return batches, nil
 }
 
+// compareBoundaries sorts two block bounds.
+//
+// KNOWN GAP: this rebuilds the btree order of each pkey type in Go, while the
+// blocks themselves were cut by ORDER BY <pkey> in the database. The two agree
+// only where the Postgres order is also the byte order or the numeric order.
+// They do not agree for a text pkey in a collation other than C ('a' < 'B' in
+// en_US.UTF-8, the other way round here), nor for an enum (sorted by
+// enumsortorder, not by label), citext, or a domain over any of these -- all of
+// which arrive here as a plain string. Where the two orders differ, some of the
+// ranges built from these bounds come out the wrong way round, select no rows,
+// and those blocks are never compared: the diff then under-reports instead of
+// failing. Measured on PostgreSQL 17 with 9 differing rows, the pre-fix uuid
+// ordering found 6 of them and a text key in en_US.utf8 found 4.
+//
+// The fix is to sort the bounds in SQL, not to add more Go cases: more cases
+// only make more types look supported. See docs/design/merkle.md, "Primary Key
+// Types and the Postgres Type Boundary".
 func (m *MerkleTreeTask) compareBoundaries(b1, b2 any) int {
 	if b1 == nil && b2 == nil {
 		return 0
@@ -2832,40 +2899,15 @@ func (m *MerkleTreeTask) compareBoundaries(b1, b2 any) int {
 			return 1
 		}
 
-		switch v1 := val1.(type) {
-		case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
-			v1Int := reflect.ValueOf(v1).Int()
-			v2Int := reflect.ValueOf(val2).Int()
-			if v1Int < v2Int {
-				return -1
-			}
-			if v1Int > v2Int {
-				return 1
-			}
-		case float32, float64:
-			v1Float := reflect.ValueOf(v1).Float()
-			v2Float := reflect.ValueOf(val2).Float()
-			if v1Float < v2Float {
-				return -1
-			}
-			if v1Float > v2Float {
-				return 1
-			}
-		case string:
-			if v1 < val2.(string) {
-				return -1
-			}
-			if v1 > val2.(string) {
-				return 1
-			}
-		case time.Time:
-			if v1.Before(val2.(time.Time)) {
-				return -1
-			}
-			if v1.After(val2.(time.Time)) {
-				return 1
-			}
-		default:
+		c, ok := comparePkeyValues(val1, val2)
+		if !ok {
+			// Nothing rejects such a bound yet, so this is reachable: fall back
+			// to the Go rendering and say so. That order rarely matches the
+			// server's, which makes the ranges built from these bounds
+			// unreliable rather than merely odd.
+			logger.Warn("cannot sort merkle-tree block bounds of type %T for %s.%s the way "+
+				"the server does; falling back to their Go rendering, so the ranges built "+
+				"from them may be wrong", val1, m.Schema, m.Table)
 			s1 := fmt.Sprintf("%v", val1)
 			s2 := fmt.Sprintf("%v", val2)
 			if s1 < s2 {
@@ -2874,6 +2916,10 @@ func (m *MerkleTreeTask) compareBoundaries(b1, b2 any) int {
 			if s1 > s2 {
 				return 1
 			}
+			continue
+		}
+		if c != 0 {
+			return c
 		}
 	}
 	if len(b1Slice) < len(b2Slice) {

--- a/internal/consistency/mtree/merkle.go
+++ b/internal/consistency/mtree/merkle.go
@@ -2450,6 +2450,11 @@ func (m *MerkleTreeTask) DiffMtree() (err error) {
 	if len(workItems) > 0 {
 		m.CompareRanges(workItems)
 
+		// Read the worker errors once, under the mutex, and use that copy
+		// below. The workers write pairCompareErrs, so no code here may read
+		// it directly.
+		m.DiffResult.Summary.IncompletePairs = m.incompletePairs()
+
 		// Mismatched blocks whose row comparison found no differences had stale
 		// tree hashes, not data divergence (typically rows applied by
 		// replication that a past drain missed). Say so -- a bare "Found N
@@ -2464,7 +2469,7 @@ func (m *MerkleTreeTask) DiffMtree() (err error) {
 			if len(entry.positions) == 0 || m.DiffResult.Summary.DiffRowsCount[pairKey] > 0 {
 				continue
 			}
-			if m.pairCompareErrs[pairKey] {
+			if slices.Contains(m.DiffResult.Summary.IncompletePairs, pairKey) {
 				logger.Warn("comparison between %s and %s was incomplete (worker errors); "+
 					"skipping stale-block refresh -- re-run the diff",
 					entry.node1["Name"], entry.node2["Name"])
@@ -2530,7 +2535,33 @@ func (m *MerkleTreeTask) DiffMtree() (err error) {
 			"guaranteed-current diff.", m.CDCSkippedNodes)
 	}
 
+	// A lost work item means the run has no result, not that the tables agree.
+	// Callers, and the exit code, must not read it as "no differences".
+	if pairs := m.DiffResult.Summary.IncompletePairs; len(pairs) > 0 {
+		return fmt.Errorf("mtree table-diff of %s.%s has no result: the range comparison "+
+			"failed part way through for node pair(s) %s (see the errors above). "+
+			"Run the diff again",
+			m.Schema, m.Table, strings.Join(pairs, ", "))
+	}
+
 	return nil
+}
+
+// incompletePairs lists the node pairs whose range comparison lost a work
+// item. The list is sorted so that the diff report does not change between
+// runs.
+func (m *MerkleTreeTask) incompletePairs() []string {
+	m.diffMutex.Lock()
+	defer m.diffMutex.Unlock()
+	if len(m.pairCompareErrs) == 0 {
+		return nil
+	}
+	pairs := make([]string, 0, len(m.pairCompareErrs))
+	for pair := range m.pairCompareErrs {
+		pairs = append(pairs, pair)
+	}
+	sort.Strings(pairs)
+	return pairs
 }
 
 // refreshStaleLeaves rehashes exactly the given leaf blocks from live table

--- a/internal/consistency/mtree/merkle.go
+++ b/internal/consistency/mtree/merkle.go
@@ -121,8 +121,14 @@ type MerkleTreeTask struct {
 	// not "no differences", so stale-block healing must not act on it. Guarded
 	// by diffMutex.
 	pairCompareErrs map[string]bool
-	StartTime       time.Time
-	NodeOriginNames map[string]map[string]string
+	// boundarySortWarned keeps the "cannot sort these bounds" warning to one
+	// line per task. It is raised from inside a sort comparator, which runs
+	// O(n log n) times per block set and again for every leaf in
+	// intervalInUnion, so one unsupported key type would otherwise repeat the
+	// same line thousands of times and bury everything else in the log.
+	boundarySortWarned sync.Once
+	StartTime          time.Time
+	NodeOriginNames    map[string]map[string]string
 
 	Ctx context.Context
 }
@@ -824,10 +830,10 @@ func buildRowHashQuery(schema, table string, key []string, cols []string, whereC
 }
 
 // pkeyKind classifies a primary-key value that pgx decoded into an untyped
-// destination. It is the one list of what mtree can handle, and three things
-// have to agree with it: comparePkeyValues sorts these kinds, pkeyIdentity
-// renders them, and validateBoundaryTypes admits them. Nothing in the language
-// ties the three together, so TestPkeyKindsAreFullySupported does.
+// destination. It is the one list of what mtree can handle, and two things
+// have to agree with it: comparePkeyValues sorts these kinds and pkeyIdentity
+// renders them. Nothing in the language ties the three together, so
+// TestPkeyKindsAreFullySupported does.
 //
 // A kind is on the list only if Go can reproduce the Postgres btree order for
 // it, and if two different values always render differently. Adding a kind
@@ -846,6 +852,12 @@ const (
 	pkeyTime
 	pkeyUUID  // pgx decodes uuid as [16]byte
 	pkeyBytes // bytea
+
+	// pkeyKindEnd is one past the last kind. It exists so
+	// TestPkeyKindsAreFullySupported can walk every kind: a new constant added
+	// above it fails that test until comparePkeyValues and pkeyIdentity handle
+	// it too. Keep it last.
+	pkeyKindEnd
 )
 
 func pkeyKindOf(v any) pkeyKind {
@@ -872,9 +884,20 @@ func pkeyKindOf(v any) pkeyKind {
 
 // comparePkeyValues orders two primary-key values of the same Go type, the way
 // the server orders that type. ok is false for a kind pkeyKindOf does not
-// know; the caller has to decide what to do about it.
+// know, and for two values that did not decode to the same kind; the caller
+// has to decide what to do about it.
 func comparePkeyValues(val1, val2 any) (result int, ok bool) {
-	switch pkeyKindOf(val1) {
+	kind := pkeyKindOf(val1)
+	// Every branch below asserts or reflects on val2 as well, so a val2 of
+	// another kind would panic rather than return ok=false. The two sides come
+	// from the same column on two nodes and should always agree, but "should"
+	// is not a guarantee across a schema mismatch, and a panic inside a sort
+	// comparator takes down the whole run.
+	if pkeyKindOf(val2) != kind {
+		return 0, false
+	}
+
+	switch kind {
 	case pkeyInt:
 		return cmp.Compare(reflect.ValueOf(val1).Int(), reflect.ValueOf(val2).Int()), true
 	case pkeyUint:
@@ -2781,14 +2804,9 @@ func (m *MerkleTreeTask) getPkeyBatches(pool1, pool2 *pgxpool.Pool, mismatchedPo
 		}
 	}
 
-	// Key each boundary by its components, not by fmt.Sprint of the whole
-	// slice: that renders []any{"a b", "c"} and []any{"a", "b c"} both as
-	// "[a b c]", so one of the two boundaries is dropped and the slice of the
-	// key space between them is never compared.
 	uniqueBoundaries := make(map[string]any)
 	for _, b := range boundaries {
-		key := utils.RowKeyFromValues(boundaryToSlice(b))
-		uniqueBoundaries[key] = b
+		uniqueBoundaries[m.boundaryKey(b)] = b
 	}
 
 	sortedBoundaries := make([]any, 0, len(uniqueBoundaries))
@@ -2844,6 +2862,43 @@ func (m *MerkleTreeTask) getPkeyBatches(pool1, pool2 *pgxpool.Pool, mismatchedPo
 	}
 
 	return batches, nil
+}
+
+// boundaryKey renders a block bound into the key that de-duplicates the cut
+// points before the ranges are rebuilt. Two bounds must share a key only if
+// they are the same bound: dropping a real cut point shifts the whole slice set
+// and can leave rows uncompared.
+//
+// fmt is not good enough for that. fmt.Sprint of the whole slice renders
+// []any{"a b","c"} and []any{"a","b c"} both as "[a b c]", and a per-component
+// %v renders two distinct uuids through the same []byte formatting. So each
+// component goes through pkeyIdentity, which is injective by contract, and the
+// components are joined by the encoder that keeps composites unambiguous.
+//
+// Each component carries a one-letter tag, so a NULL cannot be confused with a
+// value that renders as "nil" and a fmt fallback cannot be confused with an
+// identity that happens to look the same.
+func (m *MerkleTreeTask) boundaryKey(b any) string {
+	slice := boundaryToSlice(b)
+	parts := make([]string, len(slice))
+	for i, v := range slice {
+		switch {
+		case v == nil:
+			parts[i] = "n"
+		default:
+			if id, ok := pkeyIdentity(v); ok {
+				parts[i] = "v" + id
+			} else {
+				// The type is already the documented broken case: its bounds
+				// are ordered by their Go rendering too. Warn once and key it
+				// the only way left, rather than refuse a bound the sort
+				// itself still accepts.
+				m.warnBoundarySortFallback(v)
+				parts[i] = "f" + fmt.Sprintf("%v", v)
+			}
+		}
+	}
+	return utils.RowKeyFromStrings(parts)
 }
 
 // compareBoundaries sorts two block bounds.
@@ -2913,9 +2968,7 @@ func (m *MerkleTreeTask) compareBoundaries(b1, b2 any) int {
 			// to the Go rendering and say so. That order rarely matches the
 			// server's, which makes the ranges built from these bounds
 			// unreliable rather than merely odd.
-			logger.Warn("cannot sort merkle-tree block bounds of type %T for %s.%s the way "+
-				"the server does; falling back to their Go rendering, so the ranges built "+
-				"from them may be wrong", val1, m.Schema, m.Table)
+			m.warnBoundarySortFallback(val1)
 			s1 := fmt.Sprintf("%v", val1)
 			s2 := fmt.Sprintf("%v", val2)
 			if s1 < s2 {
@@ -2937,6 +2990,18 @@ func (m *MerkleTreeTask) compareBoundaries(b1, b2 any) int {
 		return 1
 	}
 	return 0
+}
+
+// warnBoundarySortFallback reports, once per task, that block bounds are being
+// ordered by their Go rendering because comparePkeyValues does not know the
+// type. The caller is a sort comparator, so this must stay cheap on the second
+// and every later call.
+func (m *MerkleTreeTask) warnBoundarySortFallback(val any) {
+	m.boundarySortWarned.Do(func() {
+		logger.Warn("cannot sort merkle-tree block bounds of type %T for %s.%s the way "+
+			"the server does; falling back to their Go rendering, so the ranges built "+
+			"from them may be wrong", val, m.Schema, m.Table)
+	})
 }
 
 func (m *MerkleTreeTask) intervalInUnion(s, e any, intervals []types.LeafRange) bool {

--- a/internal/consistency/mtree/merkle.go
+++ b/internal/consistency/mtree/merkle.go
@@ -778,6 +778,10 @@ func (m *MerkleTreeTask) addRowToDiff(nodePairKey, nodeName string, row types.Or
 	return true, nil
 }
 
+// buildRowKey renders the primary key of a diff row into the key used to
+// deduplicate rows already recorded for a node pair. It uses the same encoding
+// as the rest of the codebase so that a pkey value containing the delimiter
+// cannot make two distinct rows look like one and silently drop a difference.
 func (m *MerkleTreeTask) buildRowKey(row types.OrderedMap) (string, error) {
 	values := make([]string, len(m.Key))
 	for i, col := range m.Key {
@@ -787,7 +791,7 @@ func (m *MerkleTreeTask) buildRowKey(row types.OrderedMap) (string, error) {
 		}
 		values[i] = fmt.Sprintf("%v", val)
 	}
-	return strings.Join(values, "|"), nil
+	return utils.RowKeyFromStrings(values), nil
 }
 
 func isNumericColType(colType string) bool {
@@ -2777,9 +2781,13 @@ func (m *MerkleTreeTask) getPkeyBatches(pool1, pool2 *pgxpool.Pool, mismatchedPo
 		}
 	}
 
+	// Key each boundary by its components, not by fmt.Sprint of the whole
+	// slice: that renders []any{"a b", "c"} and []any{"a", "b c"} both as
+	// "[a b c]", so one of the two boundaries is dropped and the slice of the
+	// key space between them is never compared.
 	uniqueBoundaries := make(map[string]any)
 	for _, b := range boundaries {
-		key := fmt.Sprint(b)
+		key := utils.RowKeyFromValues(boundaryToSlice(b))
 		uniqueBoundaries[key] = b
 	}
 

--- a/internal/consistency/mtree/merkle_test.go
+++ b/internal/consistency/mtree/merkle_test.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -470,5 +471,120 @@ func TestPkeyIdentityNegativeZero(t *testing.T) {
 	}
 	if pos != neg {
 		t.Errorf("0.0 renders as %q and -0.0 as %q; Postgres treats them as equal", pos, neg)
+	}
+}
+
+// pkeyKind, comparePkeyValues and pkeyIdentity are three independent switches
+// over the same list of kinds. Nothing in the language keeps them in step, so
+// adding a kind to pkeyKindOf without teaching the other two would otherwise
+// surface as a sort that falls back to Go rendering, or a row identity that
+// refuses mid-run. Every kind needs a sample value here.
+func TestPkeyKindsAreFullySupported(t *testing.T) {
+	samples := map[pkeyKind][2]any{
+		pkeyInt:    {int64(1), int64(2)},
+		pkeyUint:   {uint64(1), uint64(2)},
+		pkeyFloat:  {1.0, 2.0},
+		pkeyBool:   {false, true},
+		pkeyString: {"a", "b"},
+		pkeyTime:   {time.Unix(0, 0).UTC(), time.Unix(1, 0).UTC()},
+		pkeyUUID:   {[16]byte{0x02}, [16]byte{0x0a}},
+		pkeyBytes:  {[]byte{0x02}, []byte{0x0a}},
+	}
+
+	// Walk the kind range rather than the map, so a newly added constant fails
+	// here instead of being quietly skipped.
+	for kind := pkeyUnsupported + 1; kind < pkeyKindEnd; kind++ {
+		pair, found := samples[kind]
+		if !found {
+			t.Errorf("kind %d has no sample value; add one when adding a kind", kind)
+			continue
+		}
+		lo, hi := pair[0], pair[1]
+
+		if got := pkeyKindOf(lo); got != kind {
+			t.Errorf("pkeyKindOf(%#v) = %d, want %d", lo, got, kind)
+		}
+
+		// comparePkeyValues must order the kind, and order it the right way.
+		c, ok := comparePkeyValues(lo, hi)
+		if !ok {
+			t.Errorf("comparePkeyValues refuses kind %d, which pkeyKindOf accepts", kind)
+		} else if c >= 0 {
+			t.Errorf("comparePkeyValues(%#v, %#v) = %d, want < 0", lo, hi, c)
+		}
+
+		// pkeyIdentity must render the kind, and render the two distinctly.
+		idLo, ok := pkeyIdentity(lo)
+		if !ok {
+			t.Errorf("pkeyIdentity refuses kind %d, which pkeyKindOf accepts", kind)
+			continue
+		}
+		idHi, ok := pkeyIdentity(hi)
+		if !ok {
+			t.Errorf("pkeyIdentity refuses kind %d, which pkeyKindOf accepts", kind)
+			continue
+		}
+		if idLo == idHi {
+			t.Errorf("kind %d renders %#v and %#v both as %q; identities must be injective",
+				kind, lo, hi, idLo)
+		}
+	}
+}
+
+// Both sides of a comparison come from the same column, but a schema mismatch
+// between nodes could still hand the comparator two different Go types. Every
+// branch asserts on val2, so this must return ok=false rather than panic.
+func TestComparePkeyValuesRejectsMixedKinds(t *testing.T) {
+	for _, pair := range [][2]any{
+		{"a", int64(1)},
+		{int64(1), "a"},
+		{[16]byte{0x01}, []byte{0x01}},
+		{1.0, int64(1)},
+		{time.Unix(0, 0), "1970-01-01"},
+	} {
+		if _, ok := comparePkeyValues(pair[0], pair[1]); ok {
+			t.Errorf("comparePkeyValues(%T, %T) claimed a valid ordering across kinds",
+				pair[0], pair[1])
+		}
+	}
+}
+
+// Bounds are de-duplicated by this key before the ranges are rebuilt, so two
+// different cut points sharing a key drops one of them and can leave rows
+// uncompared. uuids are the case fmt gets wrong: %v renders both of these
+// through the same []byte formatting.
+func TestBoundaryKeyDistinguishesBounds(t *testing.T) {
+	m := &MerkleTreeTask{}
+
+	distinct := [][]any{
+		{"a b", "c"},
+		{"a", "b c"},
+		{"a|b", "c"},
+		{"a", "b|c"},
+		{[16]byte{0x02}, "x"},
+		{[16]byte{0x0a}, "x"},
+		{nil, "x"},
+		{"", "x"},
+		{"n", "x"},
+		{"v", "x"},
+	}
+
+	seen := make(map[string][]any)
+	for _, b := range distinct {
+		key := m.boundaryKey(b)
+		if prev, clash := seen[key]; clash {
+			t.Errorf("bounds %#v and %#v share key %s", prev, b, key)
+			continue
+		}
+		seen[key] = b
+	}
+
+	// Equal bounds must still share a key, or de-duplication stops working.
+	if m.boundaryKey([]any{"a", 1}) != m.boundaryKey([]any{"a", 1}) {
+		t.Error("the same bound produced two different keys")
+	}
+	// A scalar bound and the one-element slice holding it are the same bound.
+	if m.boundaryKey("a") != m.boundaryKey([]any{"a"}) {
+		t.Error("a scalar bound and its one-element slice disagree")
 	}
 }

--- a/internal/consistency/mtree/merkle_test.go
+++ b/internal/consistency/mtree/merkle_test.go
@@ -257,6 +257,52 @@ func TestIncompletePairsReportsFailedWorkItems(t *testing.T) {
 	}
 }
 
+// uuid and bytea bounds must be sorted like uuid_cmp() and byteacmp(), not by
+// their printed Go form. 0x02 against 0x11 is the pair the fmt fallback got
+// backwards: as text, "[17 ..." comes before "[2 ...".
+func TestCompareBoundariesOrdersUUIDs(t *testing.T) {
+	m := &MerkleTreeTask{}
+	m.Key = []string{"id"}
+
+	if got := m.compareBoundaries([]byte{0x02}, []byte{0x11}); got != -1 {
+		t.Errorf("compareBoundaries(bytea 0x02, 0x11) = %d, want -1", got)
+	}
+	if got := m.compareBoundaries(false, true); got != -1 {
+		t.Errorf("compareBoundaries(false, true) = %d, want -1", got)
+	}
+	if got := m.compareBoundaries(true, false); got != 1 {
+		t.Errorf("compareBoundaries(true, false) = %d, want 1", got)
+	}
+
+	small, large := uuidBytes(0x02), uuidBytes(0x11)
+
+	if got := m.compareBoundaries(small, large); got != -1 {
+		t.Errorf("compareBoundaries(0x02.., 0x11..) = %d, want -1", got)
+	}
+	if got := m.compareBoundaries(large, small); got != 1 {
+		t.Errorf("compareBoundaries(0x11.., 0x02..) = %d, want 1", got)
+	}
+	if got := m.compareBoundaries(large, large); got != 0 {
+		t.Errorf("compareBoundaries of equal bounds = %d, want 0", got)
+	}
+}
+
+// NaN is a legal float primary key, and Postgres sorts it above every number
+// while Go's cmp.Compare puts it below. Getting this backwards inverts the
+// bounds around it.
+func TestComparePkeyValuesNaNSortsLast(t *testing.T) {
+	nan := math.NaN()
+	if got, ok := comparePkeyValues(nan, 1.0); !ok || got != 1 {
+		t.Errorf("comparePkeyValues(NaN, 1.0) = %d, %v; want 1, true", got, ok)
+	}
+	if got, ok := comparePkeyValues(1.0, nan); !ok || got != -1 {
+		t.Errorf("comparePkeyValues(1.0, NaN) = %d, %v; want -1, true", got, ok)
+	}
+	if got, ok := comparePkeyValues(nan, nan); !ok || got != 0 {
+		t.Errorf("comparePkeyValues(NaN, NaN) = %d, %v; want 0, true", got, ok)
+	}
+}
+
 func TestIsNumericColType(t *testing.T) {
 	tests := []struct {
 		colType string

--- a/internal/consistency/mtree/merkle_test.go
+++ b/internal/consistency/mtree/merkle_test.go
@@ -3,11 +3,69 @@ package mtree
 import (
 	"context"
 	"fmt"
+	"math"
 	"strings"
 	"testing"
 
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/pgedge/ace/pkg/types"
 )
+
+// fakeRows is the smallest pgx.Rows that readRowHashes needs. Scan copies
+// values into *any destinations, which is how an untyped scan buffer receives
+// the driver's own Go values: a uuid arrives as [16]byte, not as text.
+type fakeRows struct {
+	rows [][]any
+	pos  int
+}
+
+func (r *fakeRows) Close()                                       {}
+func (r *fakeRows) Err() error                                   { return nil }
+func (r *fakeRows) CommandTag() pgconn.CommandTag                { return pgconn.CommandTag{} }
+func (r *fakeRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+func (r *fakeRows) Next() bool                                   { r.pos++; return r.pos <= len(r.rows) }
+func (r *fakeRows) RawValues() [][]byte                          { return nil }
+func (r *fakeRows) Conn() *pgx.Conn                              { return nil }
+
+// current returns the row that Next stopped on. A real pgx.Rows returns an
+// error when it is read past the last row instead of panicking. Do the same
+// here, so that a later test of the error path fails with a message rather
+// than an index panic.
+func (r *fakeRows) current() ([]any, error) {
+	if r.pos < 1 || r.pos > len(r.rows) {
+		return nil, fmt.Errorf("read at position %d, outside the %d rows", r.pos, len(r.rows))
+	}
+	return r.rows[r.pos-1], nil
+}
+
+func (r *fakeRows) Values() ([]any, error) { return r.current() }
+
+func (r *fakeRows) Scan(dest ...any) error {
+	row, err := r.current()
+	if err != nil {
+		return err
+	}
+	if len(dest) != len(row) {
+		return fmt.Errorf("scanning into %d destinations, row has %d values", len(dest), len(row))
+	}
+	for i := range dest {
+		p, ok := dest[i].(*any)
+		if !ok {
+			return fmt.Errorf("dest[%d] is %T, want *any", i, dest[i])
+		}
+		*p = row[i]
+	}
+	return nil
+}
+
+func uuidBytes(b byte) [16]byte {
+	var out [16]byte
+	for i := range out {
+		out[i] = b
+	}
+	return out
+}
 
 // mtreeTaskWithDiffState returns a task wired just enough to exercise the diff
 // accumulator (appendDiffs) without a database.
@@ -105,6 +163,72 @@ func TestMtreeDiffRejectsNegativeMaxDiffRows(t *testing.T) {
 	err := m.DiffMtree()
 	if err == nil || !strings.Contains(err.Error(), "max_diff_rows must be >= 0") {
 		t.Fatalf("expected max_diff_rows validation error, got %v", err)
+	}
+}
+
+// The pkey values that reach the row-fetch query must be the ones pgx decoded,
+// not the map key. For a uuid the key prints as "[17 17 ...]", which the server
+// rejects as invalid uuid input.
+func TestReadRowHashesKeepsScannedPkey(t *testing.T) {
+	id := uuidBytes(0x11)
+	rows := &fakeRows{rows: [][]any{{id, "hash-a"}}}
+
+	got, err := readRowHashes(rows, 1)
+	if err != nil {
+		t.Fatalf("readRowHashes returned error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("read %d entries, want 1", len(got))
+	}
+	for _, e := range got {
+		if e.hash != "hash-a" {
+			t.Errorf("hash = %q, want %q", e.hash, "hash-a")
+		}
+		if len(e.pkey) != 1 {
+			t.Fatalf("pkey has %d values, want 1", len(e.pkey))
+		}
+		if e.pkey[0] != id {
+			t.Errorf("pkey[0] = %#v (%T), want the scanned [16]byte", e.pkey[0], e.pkey[0])
+		}
+	}
+}
+
+// Composite keys must not collide. Without quotes, ("a|b","c") and
+// ("a","b|c") join into the same string, and one of the two rows drops out of
+// the comparison.
+func TestReadRowHashesKeysDoNotCollide(t *testing.T) {
+	rows := &fakeRows{rows: [][]any{
+		{"a|b", "c", "hash-1"},
+		{"a", "b|c", "hash-2"},
+	}}
+
+	got, err := readRowHashes(rows, 2)
+	if err != nil {
+		t.Fatalf("readRowHashes returned error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("read %d entries, want 2 distinct keys", len(got))
+	}
+}
+
+// pkey points into the scan buffer, so that buffer has to stay inside the
+// loop. Moving it out would leave every entry pointing at the last row.
+func TestReadRowHashesRowsDoNotAlias(t *testing.T) {
+	rows := &fakeRows{rows: [][]any{
+		{uuidBytes(0x01), "hash-1"},
+		{uuidBytes(0x02), "hash-2"},
+	}}
+
+	got, err := readRowHashes(rows, 1)
+	if err != nil {
+		t.Fatalf("readRowHashes returned error: %v", err)
+	}
+	seen := make(map[[16]byte]bool, len(got))
+	for _, e := range got {
+		seen[e.pkey[0].([16]byte)] = true
+	}
+	if len(seen) != 2 {
+		t.Errorf("entries share %d distinct pkeys, want 2", len(seen))
 	}
 }
 
@@ -259,5 +383,21 @@ func TestBuildRowHashQuery(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// Postgres holds -0.0 = 0.0, so both must get one row identity. Two identities
+// would split a single row into a phantom pair of differences.
+func TestPkeyIdentityNegativeZero(t *testing.T) {
+	pos, ok := pkeyIdentity(0.0)
+	if !ok {
+		t.Fatalf("pkeyIdentity(0.0) refused")
+	}
+	neg, ok := pkeyIdentity(math.Copysign(0, -1))
+	if !ok {
+		t.Fatalf("pkeyIdentity(-0.0) refused")
+	}
+	if pos != neg {
+		t.Errorf("0.0 renders as %q and -0.0 as %q; Postgres treats them as equal", pos, neg)
 	}
 }

--- a/internal/consistency/mtree/merkle_test.go
+++ b/internal/consistency/mtree/merkle_test.go
@@ -232,6 +232,31 @@ func TestReadRowHashesRowsDoNotAlias(t *testing.T) {
 	}
 }
 
+// A lost work item means the pair has no result. The summary has to say so,
+// otherwise a diff count of zero reads as a match.
+func TestIncompletePairsReportsFailedWorkItems(t *testing.T) {
+	m := &MerkleTreeTask{}
+
+	if got := m.incompletePairs(); got != nil {
+		t.Errorf("expected no incomplete pairs on a clean task, got %v", got)
+	}
+
+	m.recordPairCompareErr("n2/n3")
+	m.recordPairCompareErr("n1/n2")
+	m.recordPairCompareErr("n1/n2")
+
+	got := m.incompletePairs()
+	want := []string{"n1/n2", "n2/n3"}
+	if len(got) != len(want) {
+		t.Fatalf("incompletePairs() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("incompletePairs() = %v, want %v (stable, sorted)", got, want)
+		}
+	}
+}
+
 func TestIsNumericColType(t *testing.T) {
 	tests := []struct {
 		colType string

--- a/pkg/common/html_reporter.go
+++ b/pkg/common/html_reporter.go
@@ -135,6 +135,16 @@ func writeHTMLDiffReport(diffResult types.DiffOutput, jsonFilePath string) (stri
 		}
 	}
 
+	// Without this, an incomplete run produces an HTML report that looks just
+	// like a clean one. People who read the report never see the worker
+	// errors, which only went to the log.
+	if len(summary.IncompletePairs) > 0 {
+		summaryItems = append(summaryItems, summaryItem{
+			Label: "Comparison Incomplete",
+			Value: strings.Join(summary.IncompletePairs, ", ") + " (counts are lower bounds)",
+		})
+	}
+
 	var filteredItems []summaryItem
 	for _, item := range summaryItems {
 		if item.Value != "" && item.Value != "0" {

--- a/pkg/common/html_reporter.go
+++ b/pkg/common/html_reporter.go
@@ -190,16 +190,26 @@ func writeHTMLDiffReport(diffResult types.DiffOutput, jsonFilePath string) (stri
 
 		columns := collectColumnsInOrder(summary.PrimaryKey, rowsA, rowsB)
 
+		// Two keys per row, and they are not interchangeable. buildRowKey is
+		// the collision-proof identity used to pair a row on A with the same
+		// row on B; buildRowDisplayKey is the plain rendering shown in the
+		// report and embedded in data-pk, which the report's own JavaScript
+		// interpolates into a CSS attribute selector and so cannot carry the
+		// quotes the identity encoding adds.
+		displayByKey := make(map[string]string, len(rowsA)+len(rowsB))
+
 		rowMapA := make(map[string]types.OrderedMap, len(rowsA))
 		for idx, row := range rowsA {
 			key := buildRowKey(row, summary.PrimaryKey, idx)
 			rowMapA[key] = row
+			displayByKey[key] = buildRowDisplayKey(row, summary.PrimaryKey, idx)
 		}
 
 		rowMapB := make(map[string]types.OrderedMap, len(rowsB))
 		for idx, row := range rowsB {
 			key := buildRowKey(row, summary.PrimaryKey, idx)
 			rowMapB[key] = row
+			displayByKey[key] = buildRowDisplayKey(row, summary.PrimaryKey, idx)
 		}
 
 		var commonKeys []string
@@ -219,9 +229,9 @@ func writeHTMLDiffReport(diffResult types.DiffOutput, jsonFilePath string) (stri
 			}
 		}
 
-		sortPKKeys(commonKeys)
-		sortPKKeys(missingInA)
-		sortPKKeys(missingInB)
+		sortPKKeys(commonKeys, displayByKey)
+		sortPKKeys(missingInA, displayByKey)
+		sortPKKeys(missingInB, displayByKey)
 
 		valueDiffs := make([]row, 0, len(commonKeys))
 		for _, key := range commonKeys {
@@ -255,7 +265,7 @@ func writeHTMLDiffReport(diffResult types.DiffOutput, jsonFilePath string) (stri
 				cells = append(cells, c)
 			}
 			valueDiffs = append(valueDiffs, row{
-				PKey:      key,
+				PKey:      displayByKey[key],
 				Cells:     cells,
 				RowType:   "value_diff",
 				HasDiffs:  hasDiffs,
@@ -282,7 +292,7 @@ func writeHTMLDiffReport(diffResult types.DiffOutput, jsonFilePath string) (stri
 					})
 				}
 				group.Rows = append(group.Rows, row{
-					PKey:      key,
+					PKey:      displayByKey[key],
 					Cells:     cells,
 					RowType:   "missing_in_b",
 					HasDiffs:  true,
@@ -310,7 +320,7 @@ func writeHTMLDiffReport(diffResult types.DiffOutput, jsonFilePath string) (stri
 					})
 				}
 				group.Rows = append(group.Rows, row{
-					PKey:     key,
+					PKey:     displayByKey[key],
 					Cells:    cells,
 					RowType:  "missing_in_a",
 					HasDiffs: true,
@@ -447,6 +457,9 @@ func buildDiffBreakdown(diffCounts map[string]int) []htmlPairCount {
 	return pairs
 }
 
+// buildRowKey returns the identity a row is matched by across the two nodes.
+// It falls back to the row's position when there is no usable primary key,
+// which pairs nothing but at least keeps distinct rows distinct.
 func buildRowKey(row types.OrderedMap, primaryKey []string, index int) string {
 	if len(primaryKey) == 0 {
 		return fmt.Sprintf("__row_%d", index)
@@ -457,6 +470,26 @@ func buildRowKey(row types.OrderedMap, primaryKey []string, index int) string {
 		return fmt.Sprintf("__row_%d", index)
 	}
 	return key
+}
+
+// buildRowDisplayKey renders the same primary key for human eyes: the raw
+// values joined by a pipe, with no quoting. Two rows whose pkey values differ
+// only in where the pipes fall share a display key; they still have distinct
+// identities, so neither is dropped from the report.
+func buildRowDisplayKey(row types.OrderedMap, primaryKey []string, index int) string {
+	if len(primaryKey) == 0 {
+		return fmt.Sprintf("__row_%d", index)
+	}
+
+	parts := make([]string, len(primaryKey))
+	for i, col := range primaryKey {
+		val, ok := row.Get(col)
+		if !ok {
+			return fmt.Sprintf("__row_%d", index)
+		}
+		parts[i] = fmt.Sprintf("%v", val)
+	}
+	return strings.Join(parts, "|")
 }
 
 func collectColumnsInOrder(primaryKey []string, rowSets ...[]types.OrderedMap) []string {
@@ -643,10 +676,32 @@ func buildRowJSONPretty(row types.OrderedMap, columns []string) string {
 	return string(b)
 }
 
-// sortPKKeys orders primary key strings using numeric-aware comparison so 2 sorts before 10.
-func sortPKKeys(keys []string) {
+// sortPKKeys orders row identity keys by their displayed primary key, using
+// numeric-aware comparison so 2 sorts before 10, and falls back to the
+// identity key itself when two displays compare equal. The identity keys are a
+// quoted encoding that comparePKKey cannot read numerically, hence the lookup
+// through display.
+func sortPKKeys(keys []string, display map[string]string) {
+	// A key with no display entry would compare as the empty string against
+	// every other one, which is not an ordering; fall back to the key itself
+	// so the report stays deterministic.
+	shown := func(key string) string {
+		if d, ok := display[key]; ok {
+			return d
+		}
+		return key
+	}
 	sort.Slice(keys, func(i, j int) bool {
-		return comparePKKey(keys[i], keys[j]) < 0
+		if c := comparePKKey(shown(keys[i]), shown(keys[j])); c != 0 {
+			return c < 0
+		}
+		// Distinct rows can share a display key -- that is the whole reason
+		// identity and display are separate -- and comparePKComponent also
+		// ties values that differ only in spelling, such as 1 and 1.0.
+		// sort.Slice is not stable and the input order comes from map
+		// iteration, so without a tie-break on the identity the report
+		// reorders those rows from one run to the next.
+		return keys[i] < keys[j]
 	})
 }
 

--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -1056,31 +1056,33 @@ func IsKnownScalarType(colType string) bool {
 // RowKeyFromStrings joins already-rendered primary-key parts into the
 // in-memory key that matches a row across nodes.
 //
-// Each part is quoted before joining. Joined raw, the composite keys
-// ("a|b","c") and ("a","b|c") produce the same string, so one of the two rows
-// silently drops out of the comparison -- in a consistency checker that is a
-// missed difference, not a cosmetic bug.
+// Joined raw, the composite keys ("a|b","c") and ("a","b|c") produce the same
+// string, so one of the two rows silently drops out of the comparison -- in a
+// consistency checker that is a missed difference, not a cosmetic bug. So a
+// part is quoted, but only when it has to be: when it is empty, or contains
+// the delimiter or a quote. An ordinary key therefore still reads as
+// 123|abc, which matters because these keys are interpolated into
+// operator-facing messages ("row missing on n2 (pk 123)").
+//
+// That rule keeps distinct part lists distinct. Reading left to right, every
+// element says where it ends: a bare element holds no quote, so it cannot be
+// mistaken for a quoted one, and holds no delimiter, so it ends at the next
+// one; a quoted element starts with a quote and ends where the string literal
+// closes. ("a|b","c") is "a|b"|c and ("a","b|c") is a|"b|c".
 //
 // The result is a matching key, not a primary key: it is never persisted, sent
 // to the server or parsed back. Code that needs real pkey values has to carry
 // them separately.
 func RowKeyFromStrings(parts []string) string {
-	quoted := make([]string, len(parts))
+	encoded := make([]string, len(parts))
 	for i, p := range parts {
-		quoted[i] = strconv.Quote(p)
+		if p == "" || strings.ContainsAny(p, "|\"") {
+			encoded[i] = strconv.Quote(p)
+		} else {
+			encoded[i] = p
+		}
 	}
-	return strings.Join(quoted, "|")
-}
-
-// RowKeyFromValues renders each value with fmt and joins them with
-// RowKeyFromStrings. fmt is lossy for driver types -- a uuid prints as
-// "[17 17 ...]" -- which is why the result must not leave the process.
-func RowKeyFromValues(vals []any) string {
-	parts := make([]string, len(vals))
-	for i, v := range vals {
-		parts[i] = fmt.Sprintf("%v", v)
-	}
-	return RowKeyFromStrings(parts)
+	return strings.Join(encoded, "|")
 }
 
 // StringifyKey renders the primary-key columns of a row into the in-memory key
@@ -1435,17 +1437,22 @@ func areRowsModified(row1, row2 types.OrderedMap, dataCols []string) (bool, erro
 	return false, nil
 }
 
+// buildPKey keys the row maps CompareRowSets matches on. It is a third caller
+// of the encoding StringifyKey and StringifyOrderedMapKey use, and has to stay
+// one: joined raw, two rows whose pkey values differ only in where
+// the delimiter falls collapse into one map entry and the modification between
+// them is never reported.
 func buildPKey(row types.OrderedMap, pkeyCols []string) (string, error) {
 	rowMap := OrderedMapToMap(row)
-	var pkeyParts []string
-	for _, pkeyCol := range pkeyCols {
+	pkeyParts := make([]string, len(pkeyCols))
+	for i, pkeyCol := range pkeyCols {
 		val, ok := rowMap[pkeyCol]
 		if !ok {
 			return "", fmt.Errorf("pkey column %s not found in row", pkeyCol)
 		}
-		pkeyParts = append(pkeyParts, fmt.Sprintf("%v", val))
+		pkeyParts[i] = fmt.Sprintf("%v", val)
 	}
-	return strings.Join(pkeyParts, "|"), nil
+	return RowKeyFromStrings(pkeyParts), nil
 }
 
 func OrderedMapToMap(om types.OrderedMap) map[string]any {
@@ -1458,7 +1465,8 @@ func OrderedMapToMap(om types.OrderedMap) map[string]any {
 
 // StringifyOrderedMapKey is StringifyKey for an OrderedMap. It must stay
 // byte-for-byte compatible with StringifyKey: the two are used interchangeably
-// to key the same maps, so a row keyed by one has to be found by the other.
+// on one map, so a row keyed by either has to be found by the other. buildPKey
+// shares the encoding but keys maps of its own.
 func StringifyOrderedMapKey(row types.OrderedMap, pkeyCols []string) (string, error) {
 	pkeyParts := make([]string, len(pkeyCols))
 	for i, pkeyCol := range pkeyCols {

--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -1053,6 +1053,36 @@ func IsKnownScalarType(colType string) bool {
 	return false
 }
 
+// RowKeyFromStrings joins already-rendered primary-key parts into the
+// in-memory key that matches a row across nodes.
+//
+// Each part is quoted before joining. Joined raw, the composite keys
+// ("a|b","c") and ("a","b|c") produce the same string, so one of the two rows
+// silently drops out of the comparison -- in a consistency checker that is a
+// missed difference, not a cosmetic bug.
+//
+// The result is a matching key, not a primary key: it is never persisted, sent
+// to the server or parsed back. Code that needs real pkey values has to carry
+// them separately.
+func RowKeyFromStrings(parts []string) string {
+	quoted := make([]string, len(parts))
+	for i, p := range parts {
+		quoted[i] = strconv.Quote(p)
+	}
+	return strings.Join(quoted, "|")
+}
+
+// RowKeyFromValues renders each value with fmt and joins them with
+// RowKeyFromStrings. fmt is lossy for driver types -- a uuid prints as
+// "[17 17 ...]" -- which is why the result must not leave the process.
+func RowKeyFromValues(vals []any) string {
+	parts := make([]string, len(vals))
+	for i, v := range vals {
+		parts[i] = fmt.Sprintf("%v", v)
+	}
+	return RowKeyFromStrings(parts)
+}
+
 func StringifyKey(row map[string]any, pkeyCols []string) (string, error) {
 	var pkeyParts []string
 	for _, pkeyCol := range pkeyCols {
@@ -1585,7 +1615,6 @@ func comparePKValues(valuesA, valuesB []any) int {
 	}
 	return 0
 }
-
 
 // CompareNumeric compares two numeric values with full precision.
 // Returns -1 if a < b, 0 if a == b, 1 if a > b, and ok=true if both

--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -1486,7 +1486,13 @@ func MapToOrderedMap(m map[string]any, cols []string) types.OrderedMap {
 }
 
 func WriteDiffReport(diffResult types.DiffOutput, schema, table, format string) (string, string, error) {
-	if len(diffResult.NodeDiffs) == 0 {
+	// An empty NodeDiffs means "the tables match" only if every node pair was
+	// really compared. If work items were lost to errors, it means "we do not
+	// know", and the summary that names those pairs is still worth writing to
+	// disk, even with no rows to show. Engines that never set IncompletePairs
+	// are not affected.
+	incomplete := len(diffResult.Summary.IncompletePairs) > 0
+	if len(diffResult.NodeDiffs) == 0 && !incomplete {
 		logger.Info("%s TABLES MATCH", CheckMark)
 		return "", "", nil
 	}
@@ -1527,9 +1533,15 @@ func WriteDiffReport(diffResult types.DiffOutput, schema, table, format string) 
 		return "", "", fmt.Errorf("failed to close diffs file: %w", err)
 	}
 
-	logger.Warn("%s TABLES DO NOT MATCH", CrossMark)
-	for key, diffCount := range diffResult.Summary.DiffRowsCount {
-		logger.Warn("Found %d differences between %s", diffCount, key)
+	if len(diffResult.NodeDiffs) > 0 {
+		logger.Warn("%s TABLES DO NOT MATCH", CrossMark)
+		for key, diffCount := range diffResult.Summary.DiffRowsCount {
+			logger.Warn("Found %d differences between %s", diffCount, key)
+		}
+	}
+	if incomplete {
+		logger.Warn("%s COMPARISON INCOMPLETE for node pair(s) %s -- the counts above are lower bounds",
+			CrossMark, strings.Join(diffResult.Summary.IncompletePairs, ", "))
 	}
 	logger.Info("Diff report written to %s", jsonFileName)
 

--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -1083,16 +1083,23 @@ func RowKeyFromValues(vals []any) string {
 	return RowKeyFromStrings(parts)
 }
 
+// StringifyKey renders the primary-key columns of a row into the in-memory key
+// that matches that row against the same row on another node. The parts are
+// encoded with RowKeyFromStrings, so a value that itself contains the
+// delimiter cannot collide with a different composite key.
+//
+// Like every RowKeyFromStrings result, this is a matching key and not a pkey
+// value: it must not reach SQL, a report or repair.
 func StringifyKey(row map[string]any, pkeyCols []string) (string, error) {
-	var pkeyParts []string
-	for _, pkeyCol := range pkeyCols {
+	pkeyParts := make([]string, len(pkeyCols))
+	for i, pkeyCol := range pkeyCols {
 		val, ok := row[pkeyCol]
 		if !ok {
 			return "", fmt.Errorf("pkey column %s not found in row", pkeyCol)
 		}
-		pkeyParts = append(pkeyParts, fmt.Sprintf("%v", val))
+		pkeyParts[i] = fmt.Sprintf("%v", val)
 	}
-	return strings.Join(pkeyParts, "|"), nil
+	return RowKeyFromStrings(pkeyParts), nil
 }
 
 func AddSpockMetadata(row map[string]any) map[string]any {
@@ -1449,16 +1456,19 @@ func OrderedMapToMap(om types.OrderedMap) map[string]any {
 	return m
 }
 
+// StringifyOrderedMapKey is StringifyKey for an OrderedMap. It must stay
+// byte-for-byte compatible with StringifyKey: the two are used interchangeably
+// to key the same maps, so a row keyed by one has to be found by the other.
 func StringifyOrderedMapKey(row types.OrderedMap, pkeyCols []string) (string, error) {
-	var pkeyParts []string
-	for _, pkeyCol := range pkeyCols {
+	pkeyParts := make([]string, len(pkeyCols))
+	for i, pkeyCol := range pkeyCols {
 		val, ok := row.Get(pkeyCol)
 		if !ok {
 			return "", fmt.Errorf("pkey column %s not found in row", pkeyCol)
 		}
-		pkeyParts = append(pkeyParts, fmt.Sprintf("%v", val))
+		pkeyParts[i] = fmt.Sprintf("%v", val)
 	}
-	return strings.Join(pkeyParts, "|"), nil
+	return RowKeyFromStrings(pkeyParts), nil
 }
 
 func MapToOrderedMap(m map[string]any, cols []string) types.OrderedMap {

--- a/pkg/common/utils_test.go
+++ b/pkg/common/utils_test.go
@@ -498,7 +498,8 @@ func TestStringifyOrderedMapKey_JsonNumber(t *testing.T) {
 
 	key, err := StringifyOrderedMapKey(row, []string{"id"})
 	require.NoError(t, err)
-	require.Equal(t, "415588913294348289", key, "PK must stringify to exact decimal, not scientific notation")
+	require.Equal(t, RowKeyFromStrings([]string{"415588913294348289"}), key,
+		"PK must stringify to exact decimal, not scientific notation")
 }
 
 func TestStringifyOrderedMapKey_JsonNumberNoPKCollision(t *testing.T) {
@@ -553,4 +554,82 @@ func TestRowKeyFromStringsIsUnambiguous(t *testing.T) {
 		RowKeyFromStrings([]string{"a", "b"}),
 		RowKeyFromStrings([]string{"a", "b"}),
 		"the same parts must always encode to the same row key")
+}
+
+// StringifyKey and StringifyOrderedMapKey key the same maps in the diff and
+// repair paths -- a row inserted under one has to be found under the other --
+// and both must inherit the unambiguous encoding, or a pkey value containing
+// the delimiter merges two distinct rows into one.
+func TestStringifyKeyEncodingIsSharedAndUnambiguous(t *testing.T) {
+	pkeyCols := []string{"a", "b"}
+
+	split1 := map[string]any{"a": "x|y", "b": "z"}
+	split2 := map[string]any{"a": "x", "b": "y|z"}
+
+	key1, err := StringifyKey(split1, pkeyCols)
+	require.NoError(t, err)
+	key2, err := StringifyKey(split2, pkeyCols)
+	require.NoError(t, err)
+	require.NotEqual(t, key1, key2, "rows whose pkey values differ must not share a key")
+
+	ordered := types.OrderedMap{{Key: "a", Value: "x|y"}, {Key: "b", Value: "z"}}
+	orderedKey, err := StringifyOrderedMapKey(ordered, pkeyCols)
+	require.NoError(t, err)
+	require.Equal(t, key1, orderedKey, "the two stringifiers must agree on the same row")
+}
+
+// Block boundaries are de-duplicated by this encoding before the key space is
+// sliced up. fmt.Sprint over the whole slice renders both of these as
+// "[a b c]", which drops one boundary and leaves the range between them
+// uncompared, so the parts have to be encoded one at a time.
+func TestRowKeyFromValuesSeparatesComponents(t *testing.T) {
+	require.NotEqual(t,
+		RowKeyFromValues([]any{"a b", "c"}),
+		RowKeyFromValues([]any{"a", "b c"}),
+		"composite boundaries that differ must not encode to the same key")
+
+	require.NotEqual(t,
+		RowKeyFromValues([]any{"a|b", "c"}),
+		RowKeyFromValues([]any{"a", "b|c"}),
+		"the delimiter inside a value must not merge two boundaries")
+
+	require.Equal(t,
+		RowKeyFromValues([]any{1, "x"}),
+		RowKeyFromValues([]any{1, "x"}),
+		"equal boundaries must encode to the same key, or dedup stops working")
+}
+
+// The report must not reorder its rows between runs on identical input. Two
+// rows can share a display key while having distinct identities, and the input
+// order comes from map iteration, so the sort needs a tie-break to be a total
+// order rather than merely a mostly-consistent one.
+func TestSortPKKeysIsDeterministicOnTiedDisplays(t *testing.T) {
+	// Both identities render as the same display string.
+	idA := RowKeyFromStrings([]string{"a|b", "c"})
+	idB := RowKeyFromStrings([]string{"a", "b|c"})
+	display := map[string]string{idA: "a|b|c", idB: "a|b|c"}
+
+	var first []string
+	for run := 0; run < 20; run++ {
+		keys := []string{idA, idB}
+		if run%2 == 1 {
+			keys = []string{idB, idA} // the map-iteration order flips too
+		}
+		sortPKKeys(keys, display)
+		if first == nil {
+			first = append([]string(nil), keys...)
+			continue
+		}
+		require.Equal(t, first, keys, "tied displays must sort to a stable order")
+	}
+
+	// Numerically equal but differently spelled displays tie the same way.
+	keys := []string{"id-b", "id-a"}
+	sortPKKeys(keys, map[string]string{"id-a": "1.0", "id-b": "1"})
+	require.Equal(t, []string{"id-a", "id-b"}, keys, "a tie falls back to the identity key")
+
+	// An ordinary numeric ordering is untouched by the tie-break.
+	keys = []string{"id-10", "id-2"}
+	sortPKKeys(keys, map[string]string{"id-2": "2", "id-10": "10"})
+	require.Equal(t, []string{"id-2", "id-10"}, keys, "2 must still sort before 10")
 }

--- a/pkg/common/utils_test.go
+++ b/pkg/common/utils_test.go
@@ -513,6 +513,33 @@ func TestStringifyOrderedMapKey_JsonNumberNoPKCollision(t *testing.T) {
 	require.NotEqual(t, key1, key2, "adjacent bigint PKs must not collide")
 }
 
+// The verdict is decided here and nowhere else, so both halves need a test.
+// An empty NodeDiffs is a match only if every node pair was really compared.
+// If work items were lost to errors it means "we do not know", and the summary
+// that names those pairs must still be written to disk.
+func TestWriteDiffReportNoMatchVerdictWhenIncomplete(t *testing.T) {
+	t.Chdir(t.TempDir()) // WriteDiffReport writes the report into the current directory
+
+	clean := types.DiffOutput{
+		Summary: types.DiffSummary{Schema: "public", Table: "t"},
+	}
+	jsonPath, _, err := WriteDiffReport(clean, "public", "t", "json")
+	require.NoError(t, err)
+	require.Empty(t, jsonPath, "a fully compared run with no diffs is a match, so nothing is written")
+
+	incomplete := types.DiffOutput{
+		Summary: types.DiffSummary{
+			Schema:          "public",
+			Table:           "t",
+			IncompletePairs: []string{"n1/n2"},
+		},
+	}
+	jsonPath, _, err = WriteDiffReport(incomplete, "public", "t", "json")
+	require.NoError(t, err)
+	require.NotEmpty(t, jsonPath, "an incomplete comparison must not be reported as a match")
+	require.FileExists(t, jsonPath)
+}
+
 // Row keys are matched across nodes, so an ambiguous encoding loses rows: with
 // the parts joined raw, ("a|b","c") and ("a","b|c") produce one key and one of
 // the two rows disappears from the comparison.

--- a/pkg/common/utils_test.go
+++ b/pkg/common/utils_test.go
@@ -578,25 +578,48 @@ func TestStringifyKeyEncodingIsSharedAndUnambiguous(t *testing.T) {
 	require.Equal(t, key1, orderedKey, "the two stringifiers must agree on the same row")
 }
 
-// Block boundaries are de-duplicated by this encoding before the key space is
-// sliced up. fmt.Sprint over the whole slice renders both of these as
-// "[a b c]", which drops one boundary and leaves the range between them
-// uncompared, so the parts have to be encoded one at a time.
-func TestRowKeyFromValuesSeparatesComponents(t *testing.T) {
-	require.NotEqual(t,
-		RowKeyFromValues([]any{"a b", "c"}),
-		RowKeyFromValues([]any{"a", "b c"}),
-		"composite boundaries that differ must not encode to the same key")
+// These keys reach operators: repair interpolates them into "row missing on %s
+// (pk %s)". So a part is quoted only when it has to be, and an ordinary key
+// still reads the way the pkey does.
+func TestRowKeyFromStringsQuotesOnlyWhenNeeded(t *testing.T) {
+	require.Equal(t, "123", RowKeyFromStrings([]string{"123"}),
+		"a plain value must not gain quotes")
+	require.Equal(t, "123|abc", RowKeyFromStrings([]string{"123", "abc"}),
+		"a plain composite must read as it always did")
 
-	require.NotEqual(t,
-		RowKeyFromValues([]any{"a|b", "c"}),
-		RowKeyFromValues([]any{"a", "b|c"}),
-		"the delimiter inside a value must not merge two boundaries")
+	// Quoting kicks in exactly where the encoding would otherwise be ambiguous.
+	require.Equal(t, `"a|b"|c`, RowKeyFromStrings([]string{"a|b", "c"}))
+	require.Equal(t, `a|"b|c"`, RowKeyFromStrings([]string{"a", "b|c"}))
+	require.Equal(t, `""`, RowKeyFromStrings([]string{""}),
+		"an empty part must still occupy its position")
+	require.Equal(t, `"say \"hi\""`, RowKeyFromStrings([]string{`say "hi"`}),
+		"a value holding a quote must be quoted, or it could pass for an encoded part")
+}
 
-	require.Equal(t,
-		RowKeyFromValues([]any{1, "x"}),
-		RowKeyFromValues([]any{1, "x"}),
-		"equal boundaries must encode to the same key, or dedup stops working")
+// The encoding has to be injective, because a collision merges two rows into
+// one map entry and drops a difference. Values that mix the delimiter, quotes
+// and empties are where a hand-rolled rule goes wrong.
+func TestRowKeyFromStringsIsInjective(t *testing.T) {
+	parts := []string{"", "a", "b", "|", `"`, "a|b", "b|c", `"a`, `a"`, `"a|b"`, `\`}
+
+	seen := make(map[string][]string)
+	for _, p1 := range parts {
+		for _, p2 := range parts {
+			key := RowKeyFromStrings([]string{p1, p2})
+			if prev, clash := seen[key]; clash {
+				t.Errorf("%q and %q both encode to %s", prev, []string{p1, p2}, key)
+				continue
+			}
+			seen[key] = []string{p1, p2}
+		}
+		// A one-part list must not collide with any two-part list either.
+		key := RowKeyFromStrings([]string{p1})
+		if prev, clash := seen[key]; clash {
+			t.Errorf("%q and %q both encode to %s", prev, []string{p1}, key)
+		} else {
+			seen[key] = []string{p1}
+		}
+	}
 }
 
 // The report must not reorder its rows between runs on identical input. Two

--- a/pkg/common/utils_test.go
+++ b/pkg/common/utils_test.go
@@ -512,3 +512,18 @@ func TestStringifyOrderedMapKey_JsonNumberNoPKCollision(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEqual(t, key1, key2, "adjacent bigint PKs must not collide")
 }
+
+// Row keys are matched across nodes, so an ambiguous encoding loses rows: with
+// the parts joined raw, ("a|b","c") and ("a","b|c") produce one key and one of
+// the two rows disappears from the comparison.
+func TestRowKeyFromStringsIsUnambiguous(t *testing.T) {
+	require.NotEqual(t,
+		RowKeyFromStrings([]string{"a|b", "c"}),
+		RowKeyFromStrings([]string{"a", "b|c"}),
+		"composite keys that differ must not encode to the same row key")
+
+	require.Equal(t,
+		RowKeyFromStrings([]string{"a", "b"}),
+		RowKeyFromStrings([]string{"a", "b"}),
+		"the same parts must always encode to the same row key")
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -134,6 +134,10 @@ type DiffSummary struct {
 	// that row comparison resolved as false positives (stale hashes, no data
 	// differences) and that the diff refreshed from live data in place.
 	StaleBlocksRefreshed map[string]int `json:"stale_blocks_refreshed,omitempty"`
+	// IncompletePairs lists the node pairs that lost a range-comparison work
+	// item to an error. For those pairs DiffRowsCount is only a lower bound,
+	// and zero means "not compared", not "no differences".
+	IncompletePairs []string `json:"incomplete_pairs,omitempty"`
 }
 
 type KVPair struct {

--- a/tests/integration/mtree_pkey_types_test.go
+++ b/tests/integration/mtree_pkey_types_test.go
@@ -1,0 +1,249 @@
+package integration
+
+// A property test over primary key types, instead of one hand-picked example
+// per type.
+//
+// The property is the whole promise of mtree: if N rows differ between two
+// nodes, the diff must report exactly those N. It holds only if ACE can
+// reproduce the Postgres order of the key type outside the database, because
+// the block bounds it builds in Go are sent back as range conditions. When the
+// two orders disagree, a range selects nothing, the block is never compared,
+// and the diff reports a match it never checked.
+//
+// The known instances -- uuid, bytea, numeric, and the text
+// collation gap -- is one instance of that. Each was found by hand, one at a
+// time, after it reached production. This test looks for the next one.
+//
+// The failures are partial, not total: restoring the pre-fix uuid and bytea
+// ordering makes the diff report 6 of 9 differing rows, and the text collation
+// case reports 4 of 9. A wrong order does not always empty a range -- often it
+// only widens one -- which is why this misses rows quietly instead of erroring.
+//
+// Three things about the setup are load-bearing. The divergence has to span
+// many blocks: with a single differing row there is one mismatched leaf, two
+// bounds and a single comparison, which a wrong comparator gets right half the
+// time by luck. That was measured -- with one row, breaking the uuid ordering
+// on purpose did not turn this test red. The block size has to leave
+// several blocks, because with one block there is nothing to order and every
+// case passes by accident. And the table is deliberately NOT added to a spock
+// replication set: the nodes have to stay divergent for the whole test, and
+// spock.repair_mode does not achieve that -- it was measured to still
+// replicate the change to the peer, after which both nodes agree again and the
+// diff has nothing to find. ACE does not need the spock repset either, since
+// mtree init puts the table into ACE's own publication and slot.
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+)
+
+// pkeyTypeCase describes one primary key type. valuesSQL must produce exactly
+// rowCount distinct values of pkType, in any order.
+type pkeyTypeCase struct {
+	name      string
+	pkType    string
+	valuesSQL string
+	// skipReason, when the check returns a non-empty string, skips the case.
+	skipReason func(t *testing.T, ctx context.Context, pool *pgxpool.Pool) string
+	// knownGap marks a case that reproduces an open defect. It is skipped so
+	// the suite stays green; deleting the field is the acceptance criterion
+	// for the fix.
+	knownGap string
+}
+
+const (
+	pkeyTypeRowCount = 500
+	// The diverging rows are spread over the interior of the key range, every
+	// pkeyTypeDivergeEvery-th row. Both ends are left alone on purpose: the
+	// last leaf of a tree carries range_end = NULL, so if it is among the
+	// mismatched blocks getPkeyBatches adds an open-ended slice. That slice
+	// covers everything the ordering may have got wrong, and the test then
+	// passes even with the bound comparison fully reversed -- measured.
+	pkeyTypeDivergeFrom  = 150
+	pkeyTypeDivergeTo    = 350
+	pkeyTypeDivergeEvery = 25
+	pkeyTypeDivergedRows = (pkeyTypeDivergeTo-pkeyTypeDivergeFrom)/pkeyTypeDivergeEvery + 1
+)
+
+func pkeyTypeCases() []pkeyTypeCase {
+	g := fmt.Sprintf("generate_series(1, %d) g", pkeyTypeRowCount)
+	return []pkeyTypeCase{
+		{
+			name:      "bigint",
+			pkType:    "BIGINT",
+			valuesSQL: "SELECT (g * 7919)::bigint FROM " + g,
+		},
+		{
+			name:   "uuid",
+			pkType: "UUID",
+			// Hashed, so the values are spread over the whole uuid range and
+			// their byte order has nothing to do with insertion order.
+			valuesSQL: "SELECT md5(g::text)::uuid FROM " + g,
+		},
+		{
+			name:      "bytea",
+			pkType:    "BYTEA",
+			valuesSQL: "SELECT decode(md5(g::text), 'hex') FROM " + g,
+		},
+		{
+			name:   "text_c_collation",
+			pkType: `TEXT COLLATE "C"`,
+			// Mixed case on purpose: this is where a byte-wise order and a
+			// linguistic one disagree.
+			valuesSQL: "SELECT CASE WHEN g % 2 = 0 THEN upper(md5(g::text)) ELSE md5(g::text) END FROM " + g,
+		},
+		{
+			// Reproduces the collation gap, and it is a real one: measured on
+			// PostgreSQL 17 the diff reported 4 of the 9 differing rows. The
+			// same collation with md5 values passes, so what matters is not the
+			// collation by itself but how far its order drifts from the byte
+			// order. Here the first character alternates case: byte order puts
+			// every uppercase before every lowercase, en_US interleaves them.
+			name:      "text_en_us_collation",
+			pkType:    `TEXT COLLATE "en_US.utf8"`,
+			valuesSQL: "SELECT CASE WHEN g % 2 = 0 THEN chr(65 + g % 26) ELSE chr(97 + g % 26) END || md5(g::text) FROM " + g,
+			knownGap: "mtree orders text bounds byte by byte while the server uses the column collation; " +
+				"fix is to order the bounds in SQL -- see Merkle Tree Architecture, \"Primary Key Types\"",
+		},
+		{
+			name:      "timestamptz",
+			pkType:    "TIMESTAMPTZ",
+			valuesSQL: "SELECT '2020-01-01Z'::timestamptz + (g * 977) * interval '1 second' FROM " + g,
+		},
+		{
+			name:      "double_precision",
+			pkType:    "DOUBLE PRECISION",
+			valuesSQL: "SELECT (g * 7919)::double precision / 97 FROM " + g,
+		},
+		{
+			name:      "text_database_collation",
+			pkType:    "TEXT",
+			valuesSQL: "SELECT CASE WHEN g % 2 = 0 THEN upper(md5(g::text)) ELSE md5(g::text) END FROM " + g,
+			skipReason: func(t *testing.T, ctx context.Context, pool *pgxpool.Pool) string {
+				// pg_database, not current_setting('lc_collate'): that GUC was
+				// removed in PostgreSQL 16.
+				var collation string
+				require.NoError(t, pool.QueryRow(ctx,
+					"SELECT datcollate FROM pg_database WHERE datname = current_database()").Scan(&collation))
+				switch strings.ToUpper(collation) {
+				case "C", "POSIX", "C.UTF-8", "C.UTF8":
+					return ""
+				}
+				// Not a passing case dressed up as a skip: mtree sorts text
+				// bounds byte by byte, so under this collation it can order
+				// them differently than the server did and miss the row. The
+				// fix is to sort the bounds in SQL; until then the run is
+				// skipped rather than expected to pass.
+				return fmt.Sprintf("database collation is %s, not byte-ordered; "+
+					"see Merkle Tree Architecture, \"Primary Key Types\"", collation)
+			},
+		},
+	}
+}
+
+func TestMtreePkeyTypesFindDivergence(t *testing.T) {
+	ctx := context.Background()
+	env := newSpockEnv()
+	pools := []*pgxpool.Pool{env.N1Pool, env.N2Pool}
+
+	for _, tc := range pkeyTypeCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.knownGap != "" {
+				t.Skip(tc.knownGap)
+			}
+			if tc.skipReason != nil {
+				if reason := tc.skipReason(t, ctx, env.N1Pool); reason != "" {
+					t.Skip(reason)
+				}
+			}
+
+			tableName := "mtree_pkey_" + tc.name
+			qualified := fmt.Sprintf("%s.%s", testSchema, tableName)
+			safe := pgx.Identifier{testSchema, tableName}.Sanitize()
+
+			for _, pool := range pools {
+				_, err := pool.Exec(ctx, fmt.Sprintf( // nosemgrep
+					"CREATE TABLE IF NOT EXISTS %s (id %s PRIMARY KEY, val TEXT)", safe, tc.pkType))
+				require.NoError(t, err)
+			}
+			t.Cleanup(func() {
+				for _, pool := range pools {
+					_, _ = pool.Exec(ctx, "DROP TABLE IF EXISTS "+safe+" CASCADE") // nosemgrep
+				}
+			})
+
+			for _, pool := range pools {
+				_, err := pool.Exec(ctx, fmt.Sprintf( // nosemgrep
+					"INSERT INTO %s (id, val) SELECT v, 'same' FROM (%s) s(v)", safe, tc.valuesSQL))
+				require.NoError(t, err)
+				_, err = pool.Exec(ctx, "ANALYZE "+safe) // nosemgrep
+				require.NoError(t, err)
+			}
+
+			// Remove the diff report this test produces. Left behind, a later test that
+			// repairs from "the most recent diff file" picks it up and fails with a
+			// table mismatch -- measured against TestMerkleTreeSimplePK.
+			t.Cleanup(func() {
+				files, _ := filepath.Glob("*_diffs-*.json")
+				for _, f := range files {
+					os.Remove(f)
+				}
+				files, _ = filepath.Glob("*_diffs-*.html")
+				for _, f := range files {
+					os.Remove(f)
+				}
+			})
+
+			task := env.newMerkleTreeTask(t, qualified, []string{env.ServiceN1, env.ServiceN2})
+			// Several blocks, so the bounds really are cut, sorted and merged.
+			// With one block there is nothing to order and every case would
+			// pass by accident.
+			task.BlockSize = 100
+			task.OverrideBlockSize = true
+			require.NoError(t, task.RunChecks(false))
+			require.NoError(t, task.MtreeInit())
+			t.Cleanup(func() { _ = task.MtreeTeardown() })
+			require.NoError(t, task.BuildMtree())
+
+			// Diverge rows spread evenly over the key order, so every block
+			// holds at least one and the bound set is large enough for a wrong
+			// comparator to invert some pair of it.
+			tag, err := env.N1Pool.Exec(ctx, fmt.Sprintf( // nosemgrep
+				`WITH ranked AS (SELECT id, row_number() OVER (ORDER BY id) AS rn FROM %s)
+				 UPDATE %s SET val = 'diverged'
+				 WHERE id IN (SELECT id FROM ranked WHERE rn BETWEEN %d AND %d AND rn %% %d = 0)`,
+				safe, safe, pkeyTypeDivergeFrom, pkeyTypeDivergeTo, pkeyTypeDivergeEvery))
+			require.NoError(t, err)
+			require.EqualValues(t, pkeyTypeDivergedRows, tag.RowsAffected(),
+				"the divergence must land in the interior blocks")
+
+			// Verify the arrange step before acting on it: a test that assumes
+			// a divergence it never created would pass for the wrong reason.
+			var stillSame int
+			require.NoError(t, env.N2Pool.QueryRow(ctx, // nosemgrep
+				"SELECT count(*) FROM "+safe+" WHERE val = 'diverged'").Scan(&stillSame))
+			require.Zero(t, stillSame, "the change must not have reached the peer node")
+
+			require.NoError(t, task.DiffMtree())
+			require.Empty(t, task.DiffResult.Summary.IncompletePairs,
+				"the comparison must finish, otherwise the count below means nothing")
+
+			total := 0
+			for _, c := range task.DiffResult.Summary.DiffRowsCount {
+				total += c
+			}
+			require.Equal(t, pkeyTypeDivergedRows, total,
+				"%d rows differ, so the diff must report exactly that many; a smaller number "+
+					"means some block was skipped because its bounds were ordered differently "+
+					"than on the server", pkeyTypeDivergedRows)
+		})
+	}
+}

--- a/tests/integration/mtree_uuid_pkey_test.go
+++ b/tests/integration/mtree_uuid_pkey_test.go
@@ -113,6 +113,9 @@ func TestMtreeUUIDPrimaryKeyDiff(t *testing.T) {
 	// Before the fix this returned nil after it logged a 22P02 from the worker.
 	require.NoError(t, task.DiffMtree(), "diff of a uuid-PK table must not fail")
 
+	require.Empty(t, task.DiffResult.Summary.IncompletePairs,
+		"the comparison must finish: a failed work item would make the result meaningless")
+
 	total := 0
 	for _, c := range task.DiffResult.Summary.DiffRowsCount {
 		total += c

--- a/tests/integration/mtree_uuid_pkey_test.go
+++ b/tests/integration/mtree_uuid_pkey_test.go
@@ -1,0 +1,139 @@
+package integration
+
+// "mtree table-diff" failed on any table with a uuid primary key, as soon as
+// the two nodes really disagreed on a row.
+//
+// readRowHashes built its map key by printing the scanned pkey, and the keys of
+// the mismatched rows were then used as parameters of the row-fetch query. pgx
+// decodes a uuid as [16]byte, so the parameter was the text "[17 17 ...]" and
+// the server rejected it with SQLSTATE 22P02. The worker error was logged and
+// then dropped, so the run still finished with "TABLES MATCH".
+//
+// So the diff must find the differing row AND must not claim a match.
+//
+// The table is deliberately NOT added to a spock replication set. The two
+// nodes have to stay divergent for the whole test, and spock.repair_mode does
+// not achieve that: it was measured to still replicate the change to the peer,
+// after which both nodes agree again and the diff has nothing to find. ACE
+// does not need the spock repset either -- mtree init puts the table into ACE's
+// own publication and slot.
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+)
+
+const uuidPkeyRowCount = 500
+
+func TestMtreeUUIDPrimaryKeyDiff(t *testing.T) {
+	ctx := context.Background()
+	env := newSpockEnv()
+
+	tableName := "mtree_uuid_pkey"
+	qualified := fmt.Sprintf("%s.%s", testSchema, tableName)
+	safe := pgx.Identifier{testSchema, tableName}.Sanitize()
+
+	pools := []*pgxpool.Pool{env.N1Pool, env.N2Pool}
+
+	for _, pool := range pools {
+		_, err := pool.Exec(ctx, "CREATE TABLE IF NOT EXISTS "+safe+" (id uuid PRIMARY KEY, val text)") // nosemgrep
+		require.NoError(t, err)
+	}
+	t.Cleanup(func() {
+		for _, pool := range pools {
+			_, _ = pool.Exec(ctx, "DROP TABLE IF EXISTS "+safe+" CASCADE") // nosemgrep
+		}
+	})
+
+	// md5 spreads the keys over the whole uuid range, so their byte order has
+	// nothing to do with insertion order and the block bounds really have to be
+	// sorted as uuids.
+	for _, pool := range pools {
+		_, err := pool.Exec(ctx, fmt.Sprintf( // nosemgrep
+			"INSERT INTO %s (id, val) SELECT md5(g::text)::uuid, 'same' "+
+				"FROM generate_series(1, %d) g", safe, uuidPkeyRowCount))
+		require.NoError(t, err)
+		_, err = pool.Exec(ctx, "ANALYZE "+safe) // nosemgrep
+		require.NoError(t, err)
+	}
+
+	// Remove the diff report this test produces. Left behind, a later test that
+	// repairs from "the most recent diff file" picks it up and fails with a
+	// table mismatch -- measured against TestMerkleTreeSimplePK.
+	t.Cleanup(func() {
+		files, _ := filepath.Glob("*_diffs-*.json")
+		for _, f := range files {
+			os.Remove(f)
+		}
+		files, _ = filepath.Glob("*_diffs-*.html")
+		for _, f := range files {
+			os.Remove(f)
+		}
+	})
+
+	task := env.newMerkleTreeTask(t, qualified, []string{env.ServiceN1, env.ServiceN2})
+	// Several blocks, so the bounds are really cut, sorted and merged. With one
+	// block there is nothing to order and the test would pass by accident.
+	task.BlockSize = 100
+	task.OverrideBlockSize = true
+	require.NoError(t, task.RunChecks(false))
+	require.NoError(t, task.MtreeInit())
+	t.Cleanup(func() { _ = task.MtreeTeardown() })
+	require.NoError(t, task.BuildMtree())
+
+	// Pick the row by the server's own ordering, so it lands inside a block
+	// rather than on a boundary.
+	var divergedID string
+	require.NoError(t, env.N1Pool.QueryRow(ctx, fmt.Sprintf( // nosemgrep
+		"SELECT id::text FROM %s ORDER BY id OFFSET %d LIMIT 1", safe, uuidPkeyRowCount/2)).Scan(&divergedID))
+
+	tag, err := env.N1Pool.Exec(ctx, // nosemgrep
+		"UPDATE "+safe+" SET val = 'diverged' WHERE id = $1::uuid", divergedID)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, tag.RowsAffected(), "exactly one row must diverge")
+
+	// Verify the arrange step before acting on it: if the change had reached
+	// the peer, the nodes would still be identical and everything below would
+	// pass or fail for the wrong reason.
+	var n1Val, n2Val string
+	require.NoError(t, env.N1Pool.QueryRow(ctx, // nosemgrep
+		"SELECT val FROM "+safe+" WHERE id = $1::uuid", divergedID).Scan(&n1Val))
+	require.NoError(t, env.N2Pool.QueryRow(ctx, // nosemgrep
+		"SELECT val FROM "+safe+" WHERE id = $1::uuid", divergedID).Scan(&n2Val))
+	require.NotEqual(t, n1Val, n2Val,
+		"the nodes must actually diverge before the diff runs (n1=%q n2=%q)", n1Val, n2Val)
+
+	// Before the fix this returned nil after it logged a 22P02 from the worker.
+	require.NoError(t, task.DiffMtree(), "diff of a uuid-PK table must not fail")
+
+	total := 0
+	for _, c := range task.DiffResult.Summary.DiffRowsCount {
+		total += c
+	}
+	require.Equal(t, 1, total, "expected exactly the one diverging row to be reported")
+
+	// table-repair reads this report, so the pkey has to be a value Postgres
+	// can parse back, not a printed byte array.
+	found := false
+	for _, pairDiff := range task.DiffResult.NodeDiffs {
+		for _, rows := range pairDiff.Rows {
+			for _, row := range rows {
+				for _, kv := range row {
+					if kv.Key == "id" {
+						require.Equal(t, divergedID, fmt.Sprintf("%v", kv.Value),
+							"the primary key must come back as normal uuid text")
+						found = true
+					}
+				}
+			}
+		}
+	}
+	require.True(t, found, "diff report must contain the diverging row")
+}


### PR DESCRIPTION
## What was wrong

`mtree table-diff` failed on any table whose primary key is `uuid`, but only once the two nodes actually disagreed on a row.

Two separate defects, both in this branch.

**1. A rendered map key was used as a query parameter.**
`readRowHashes` builds a map keyed on `fmt` of the scanned primary key so it can match rows across nodes. The keys of the *mismatched* rows were then reused as parameters of the row-fetch query. pgx decodes a `uuid` into a bare `[16]byte`, which Go prints as `[17 17 ...]`, so the server was handed that text as a uuid and rejected it.

**2. The failure was swallowed.**
The worker error was logged and dropped. The run went on to print `✔ TABLES MATCH` and exit 0. That is why a hard failure on every diverged uuid-keyed table stayed invisible until a customer reported it: the tool was answering "no differences" for a comparison it had never completed.

## What changed

`readRowHashes` now keeps the decoded values next to the hash, and the row-fetch query uses those. The map key stays what it always was — a way to match rows across nodes — but it can no longer reach SQL.

`splitCompositeKey` is gone with it: rebuilding primary key values out of a rendering *is* the defect, not a helper worth keeping.

Two supporting changes:

- `pkeyIdentity` renders each value through an explicit type switch instead of  `fmt`, so row identity no longer depends on how a driver happens to format a value.
- `RowKeyFromStrings` quotes each part before joining, so the composite keys  `("a|b","c")` and `("a","b|c")` stop collapsing into one entry — which silently dropped one of the two rows from the comparison.

Node pairs that lost a range-comparison work item are recorded in the diff summary (`incomplete_pairs`), and one place decides the verdict. An empty `NodeDiffs` now means "the tables match" only when every pair was really
compared. Otherwise:

- `TABLES MATCH` is not printed;
- the report is still written to disk — the failed pairs are worth keeping;
- `DiffMtree` returns an error, so the exit code stops claiming success;
- the HTML report carries the same list, for whoever reads the report rather than the log.

For a consistency checker, "I do not know" has to be distinguishable from "no differences". A zero count for a pair that was never compared is the one answer the tool must never give.

## Behaviour change reviewers, and QA need to know

**`mtree table-diff` now exits non-zero when a comparison did not finish.**
Previously, such a run exited with code 0 and a clean verdict. Anything that schedules this command and checks the exit code — cron, the HTTP API — will start seeing failures where it previously saw success. That is the intent, but it is visible and should be included in the release notes.

**A `numeric` primary key — or any type the driver decodes into a struct — now fails the run instead of under-reporting.**
Row identity cannot be built for such a value, so the first mismatched block ends the comparison with an error, the pair is recorded in `incomplete_pairs`, and the command exits with a non-zero status. Previously, the same table produced a verdict from bounds ordered by their Go rendering. Note the limit of this: a table whose blocks all match still reports a match, because the refusal occurs where rows must be matched, not at build time.

Nothing else changes for a healthy run: a clean comparison still prints `TABLES MATCH` and exits 0, and a real divergence still prints `TABLES DO NOT MATCH` and writes the same report as before.

## Known limitation, unchanged by this PR

A `text` primary key under a collation other than `C` still sorts differently in Go than on the server, and the diff can under-report as a result (measured: 4 of 9 rows). It is documented and has a reproducer, skipped, in the property test that comes with patch `0010`. The real fix is to order the bounds in SQL.
